### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/433/421166433.geojson
+++ b/data/421/166/433/421166433.geojson
@@ -165,6 +165,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008690,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"a0462ecbd139a6bf242f923eb4935d02",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421166433,
-    "wof:lastmodified":1534379080,
+    "wof:lastmodified":1582358624,
     "wof:name":"La Paz",
     "wof:parent_id":1108718357,
     "wof:placetype":"locality",

--- a/data/421/166/595/421166595.geojson
+++ b/data/421/166/595/421166595.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008695,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03f44aa520805a293cfa1bdac48e9fae",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421166595,
-    "wof:lastmodified":1566588113,
+    "wof:lastmodified":1582358623,
     "wof:name":"Juarez Celman",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/166/623/421166623.geojson
+++ b/data/421/166/623/421166623.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008696,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3e5b8e9441322171037c4114a25ef68",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421166623,
-    "wof:lastmodified":1566588117,
+    "wof:lastmodified":1582358624,
     "wof:name":"Jachal",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/166/627/421166627.geojson
+++ b/data/421/166/627/421166627.geojson
@@ -425,6 +425,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008696,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d8ec046db32508cfd6060258a41eada",
     "wof:hierarchy":[
         {
@@ -435,7 +438,7 @@
         }
     ],
     "wof:id":421166627,
-    "wof:lastmodified":1566588114,
+    "wof:lastmodified":1582358623,
     "wof:name":"San Antonio",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/166/643/421166643.geojson
+++ b/data/421/166/643/421166643.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008697,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74073e1225ca5bc9a8b400b355b06e24",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421166643,
-    "wof:lastmodified":1566588113,
+    "wof:lastmodified":1582358623,
     "wof:name":"General Alvear",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/166/645/421166645.geojson
+++ b/data/421/166/645/421166645.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008697,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0407889d0f42429bd17e5f25846402c8",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421166645,
-    "wof:lastmodified":1566588114,
+    "wof:lastmodified":1582358623,
     "wof:name":"Tehuelches",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/166/647/421166647.geojson
+++ b/data/421/166/647/421166647.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008697,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d345770143db0a6f40b122a4b62279c",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421166647,
-    "wof:lastmodified":1566588117,
+    "wof:lastmodified":1582358623,
     "wof:name":"Paso De Indios",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/166/803/421166803.geojson
+++ b/data/421/166/803/421166803.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008703,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"189404eb458530f9d1eedd4b5ca28cd1",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421166803,
-    "wof:lastmodified":1566588115,
+    "wof:lastmodified":1582358623,
     "wof:name":"Cachi",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/166/875/421166875.geojson
+++ b/data/421/166/875/421166875.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008705,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3ca86713c150c5a171356758ecf335e",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421166875,
-    "wof:lastmodified":1566588115,
+    "wof:lastmodified":1582358623,
     "wof:name":"Castellanos",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/167/065/421167065.geojson
+++ b/data/421/167/065/421167065.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008712,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"90e7766a125667a8aa6770048d747963",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421167065,
-    "wof:lastmodified":1566588144,
+    "wof:lastmodified":1582358625,
     "wof:name":"Tinogasta",
     "wof:parent_id":1108718161,
     "wof:placetype":"locality",

--- a/data/421/167/803/421167803.geojson
+++ b/data/421/167/803/421167803.geojson
@@ -179,6 +179,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008744,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"91d38d14b1c6815ce6ca2526acc8b080",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
         }
     ],
     "wof:id":421167803,
-    "wof:lastmodified":1566588144,
+    "wof:lastmodified":1582358625,
     "wof:name":"San Justo",
     "wof:parent_id":421171505,
     "wof:placetype":"locality",

--- a/data/421/168/271/421168271.geojson
+++ b/data/421/168/271/421168271.geojson
@@ -184,6 +184,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008760,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"e86e103fc3fa05053ea4c026d2b3d920",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421168271,
-    "wof:lastmodified":1561793217,
+    "wof:lastmodified":1582358622,
     "wof:name":"Trancas",
     "wof:parent_id":1108718531,
     "wof:placetype":"locality",

--- a/data/421/168/273/421168273.geojson
+++ b/data/421/168/273/421168273.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008760,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"b49ad6eddc5f4afbbf6a84f57a62a590",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421168273,
-    "wof:lastmodified":1561793216,
+    "wof:lastmodified":1582358622,
     "wof:name":"Sarmiento",
     "wof:parent_id":421171529,
     "wof:placetype":"locality",

--- a/data/421/168/279/421168279.geojson
+++ b/data/421/168/279/421168279.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008760,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"58106a4aa372e3725ebc3500181c0fb6",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421168279,
-    "wof:lastmodified":1566588112,
+    "wof:lastmodified":1582358622,
     "wof:name":"Ingeniero Jacobacci",
     "wof:parent_id":1108718401,
     "wof:placetype":"locality",

--- a/data/421/169/771/421169771.geojson
+++ b/data/421/169/771/421169771.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008823,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ace0e6a900a7bfe89b476e854a728d1f",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":421169771,
-    "wof:lastmodified":1566588148,
+    "wof:lastmodified":1582358625,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/169/773/421169773.geojson
+++ b/data/421/169/773/421169773.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008823,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6cdb759ddfcb10314f4f57137b2ede7b",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421169773,
-    "wof:lastmodified":1566588152,
+    "wof:lastmodified":1582358625,
     "wof:name":"Lujan De Cuyo",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/169/775/421169775.geojson
+++ b/data/421/169/775/421169775.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008824,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b5261896cf9e32a9cf8aef89639f331",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421169775,
-    "wof:lastmodified":1566588151,
+    "wof:lastmodified":1582358625,
     "wof:name":"\u00d1orquin",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/169/777/421169777.geojson
+++ b/data/421/169/777/421169777.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008824,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e167b01fa822181c6059e9c03a2f997",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421169777,
-    "wof:lastmodified":1566588148,
+    "wof:lastmodified":1582358625,
     "wof:name":"Confluencia",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/169/779/421169779.geojson
+++ b/data/421/169/779/421169779.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008824,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ece434c703bd43085703b23be174994c",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421169779,
-    "wof:lastmodified":1566588148,
+    "wof:lastmodified":1582358625,
     "wof:name":"Escalante",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/169/781/421169781.geojson
+++ b/data/421/169/781/421169781.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008824,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3662d540cd795b8dee274204d052b1d0",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421169781,
-    "wof:lastmodified":1566588151,
+    "wof:lastmodified":1582358625,
     "wof:name":"Doctor Manuel Belgrano",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/170/121/421170121.geojson
+++ b/data/421/170/121/421170121.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008837,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"081f7ba45bd9b95f74b44c4b795f495e",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421170121,
-    "wof:lastmodified":1566588299,
+    "wof:lastmodified":1582358639,
     "wof:name":"Las Heras",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/170/123/421170123.geojson
+++ b/data/421/170/123/421170123.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008837,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08939ad48ce8fe1bede4542832667e0b",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421170123,
-    "wof:lastmodified":1566588301,
+    "wof:lastmodified":1582358639,
     "wof:name":"A\u00f1elo",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/170/125/421170125.geojson
+++ b/data/421/170/125/421170125.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008837,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f952b15a0418d4a4a35e5f583a1d78",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421170125,
-    "wof:lastmodified":1566588301,
+    "wof:lastmodified":1582358639,
     "wof:name":"Cushamen",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/170/127/421170127.geojson
+++ b/data/421/170/127/421170127.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008837,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfb9a1ec6d36e005626db2dfc0899dc9",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421170127,
-    "wof:lastmodified":1566588298,
+    "wof:lastmodified":1582358639,
     "wof:name":"Futaleufu",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/170/131/421170131.geojson
+++ b/data/421/170/131/421170131.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008838,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"316fb21675ca0457ece47c486fb3ef90",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421170131,
-    "wof:lastmodified":1566588300,
+    "wof:lastmodified":1582358639,
     "wof:name":"Gaiman",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/170/133/421170133.geojson
+++ b/data/421/170/133/421170133.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008838,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67dc7d172caf43ba4d2edab398387a9b",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421170133,
-    "wof:lastmodified":1566588296,
+    "wof:lastmodified":1582358638,
     "wof:name":"Lago Buenos Aires",
     "wof:parent_id":85667991,
     "wof:placetype":"county",

--- a/data/421/170/351/421170351.geojson
+++ b/data/421/170/351/421170351.geojson
@@ -191,6 +191,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008850,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4634759c48550a459e9a0b5575a6ee25",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":421170351,
-    "wof:lastmodified":1566588300,
+    "wof:lastmodified":1582358639,
     "wof:name":"Sunchales",
     "wof:parent_id":421166875,
     "wof:placetype":"locality",

--- a/data/421/170/503/421170503.geojson
+++ b/data/421/170/503/421170503.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008856,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d6b8140a6e0dfc02b1f6880b788414e6",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421170503,
-    "wof:lastmodified":1566588296,
+    "wof:lastmodified":1582358639,
     "wof:name":"Punilla",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/171/213/421171213.geojson
+++ b/data/421/171/213/421171213.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08f4c1a58e477fd4b1b7f28596cc871d",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421171213,
-    "wof:lastmodified":1566588336,
+    "wof:lastmodified":1582358643,
     "wof:name":"Cerrillos",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/171/231/421171231.geojson
+++ b/data/421/171/231/421171231.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008886,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68293a4f3ffb70103d2c29daed5d8796",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421171231,
-    "wof:lastmodified":1566588336,
+    "wof:lastmodified":1582358643,
     "wof:name":"Belgrano",
     "wof:parent_id":85668029,
     "wof:placetype":"county",

--- a/data/421/171/243/421171243.geojson
+++ b/data/421/171/243/421171243.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008886,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"daba67cbffcaca4020055589c0317237",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421171243,
-    "wof:lastmodified":1566588326,
+    "wof:lastmodified":1582358642,
     "wof:name":"El Carmen",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/171/259/421171259.geojson
+++ b/data/421/171/259/421171259.geojson
@@ -328,6 +328,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6317bf14b00dadc8b11c77085c8b505",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         }
     ],
     "wof:id":421171259,
-    "wof:lastmodified":1566588327,
+    "wof:lastmodified":1582358642,
     "wof:name":"San Pedro",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/171/265/421171265.geojson
+++ b/data/421/171/265/421171265.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1b36ff636805c382900a75bc5830fc0",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421171265,
-    "wof:lastmodified":1566588337,
+    "wof:lastmodified":1582358644,
     "wof:name":"Susques",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/171/271/421171271.geojson
+++ b/data/421/171/271/421171271.geojson
@@ -196,6 +196,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46de0a3a27aa0ed63778d8e3635326aa",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         }
     ],
     "wof:id":421171271,
-    "wof:lastmodified":1566588335,
+    "wof:lastmodified":1582358643,
     "wof:name":"Tupungato",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/171/273/421171273.geojson
+++ b/data/421/171/273/421171273.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93600bcee9c2f5398f01217fa2641a70",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421171273,
-    "wof:lastmodified":1566588325,
+    "wof:lastmodified":1582358641,
     "wof:name":"Nogoya",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/171/455/421171455.geojson
+++ b/data/421/171/455/421171455.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008894,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54a45a364f25ab6fbb9f280db25cfed1",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":421171455,
-    "wof:lastmodified":1566588328,
+    "wof:lastmodified":1582358642,
     "wof:name":"Mercedes",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/171/463/421171463.geojson
+++ b/data/421/171/463/421171463.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"534de12fcd564a013b119d2d9ed205ea",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421171463,
-    "wof:lastmodified":1566588327,
+    "wof:lastmodified":1582358642,
     "wof:name":"San Justo",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/171/465/421171465.geojson
+++ b/data/421/171/465/421171465.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"703e0db8dd48053cd3b4f152857a057d",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171465,
-    "wof:lastmodified":1566588328,
+    "wof:lastmodified":1582358642,
     "wof:name":"Tercero Arriba",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/171/467/421171467.geojson
+++ b/data/421/171/467/421171467.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"baf008b95340486117f5af4986da6965",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421171467,
-    "wof:lastmodified":1566588336,
+    "wof:lastmodified":1582358644,
     "wof:name":"Parana",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/171/469/421171469.geojson
+++ b/data/421/171/469/421171469.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"713d139939201dfc845149e1502e684d",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421171469,
-    "wof:lastmodified":1566588337,
+    "wof:lastmodified":1582358644,
     "wof:name":"Marcos Juarez",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/171/473/421171473.geojson
+++ b/data/421/171/473/421171473.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43913b05f93b47e4e2e49d1da8df04d6",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":421171473,
-    "wof:lastmodified":1566588335,
+    "wof:lastmodified":1582358643,
     "wof:name":"Ayacucho",
     "wof:parent_id":85668029,
     "wof:placetype":"county",

--- a/data/421/171/477/421171477.geojson
+++ b/data/421/171/477/421171477.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58b7b9ad1400ad133407c3c7f1c8df83",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421171477,
-    "wof:lastmodified":1566588326,
+    "wof:lastmodified":1582358641,
     "wof:name":"Coronel Pringles",
     "wof:parent_id":85668029,
     "wof:placetype":"county",

--- a/data/421/171/483/421171483.geojson
+++ b/data/421/171/483/421171483.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3033be2d3a1e26b2e721d7752a5f10d3",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171483,
-    "wof:lastmodified":1566588326,
+    "wof:lastmodified":1582358642,
     "wof:name":"Rosario De La Frontera",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/171/485/421171485.geojson
+++ b/data/421/171/485/421171485.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81112cceb6127df1e0f207b263c4cf1a",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421171485,
-    "wof:lastmodified":1566588325,
+    "wof:lastmodified":1582358641,
     "wof:name":"Tunuyan",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/171/489/421171489.geojson
+++ b/data/421/171/489/421171489.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"167ca6a0777f9b9cd290ef6bd1e258cb",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421171489,
-    "wof:lastmodified":1566588335,
+    "wof:lastmodified":1582358643,
     "wof:name":"Iruya",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/171/491/421171491.geojson
+++ b/data/421/171/491/421171491.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd62198a02d0e14aebc3f59631982783",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421171491,
-    "wof:lastmodified":1566588329,
+    "wof:lastmodified":1582358642,
     "wof:name":"Pocho",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/171/495/421171495.geojson
+++ b/data/421/171/495/421171495.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a9e603739124e0535f4cb9f546f0d90",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421171495,
-    "wof:lastmodified":1566588338,
+    "wof:lastmodified":1582358644,
     "wof:name":"Ituzaingo",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/171/499/421171499.geojson
+++ b/data/421/171/499/421171499.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d9bb312ef3bf00fd28e172dec3c7e2b",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171499,
-    "wof:lastmodified":1566588328,
+    "wof:lastmodified":1582358642,
     "wof:name":"Paso De Los Libres",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/171/501/421171501.geojson
+++ b/data/421/171/501/421171501.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9595f4ceaf9db35629f7a6645b3a1c28",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421171501,
-    "wof:lastmodified":1566588332,
+    "wof:lastmodified":1582358643,
     "wof:name":"Comandante Fernandez",
     "wof:parent_id":85668063,
     "wof:placetype":"county",

--- a/data/421/171/503/421171503.geojson
+++ b/data/421/171/503/421171503.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"938a4e934d33610742e14b965f0dd0e0",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171503,
-    "wof:lastmodified":1566588324,
+    "wof:lastmodified":1582358641,
     "wof:name":"Islas Del Ibicuy",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/171/505/421171505.geojson
+++ b/data/421/171/505/421171505.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"337af1d0cdcc8d1d55f40062e41a07b6",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421171505,
-    "wof:lastmodified":1566588323,
+    "wof:lastmodified":1582358641,
     "wof:name":"San Justo",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/171/507/421171507.geojson
+++ b/data/421/171/507/421171507.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22c655cb75bfff55e4bef37e75c57e45",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421171507,
-    "wof:lastmodified":1566588333,
+    "wof:lastmodified":1582358643,
     "wof:name":"Caseros",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/171/509/421171509.geojson
+++ b/data/421/171/509/421171509.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21a88d04d0790ec91c859e42fe827dc4",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171509,
-    "wof:lastmodified":1566588334,
+    "wof:lastmodified":1582358643,
     "wof:name":"Rosario",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/171/511/421171511.geojson
+++ b/data/421/171/511/421171511.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64ff8f36cfc9ad0151c9b3db4b25edca",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421171511,
-    "wof:lastmodified":1566588331,
+    "wof:lastmodified":1582358643,
     "wof:name":"Iglesia",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/171/513/421171513.geojson
+++ b/data/421/171/513/421171513.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aab087b670307fb77f72146e0ab2c0e4",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171513,
-    "wof:lastmodified":1566588339,
+    "wof:lastmodified":1582358644,
     "wof:name":"Calingasta",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/171/517/421171517.geojson
+++ b/data/421/171/517/421171517.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"442fcf92b8f5782545773d9bc71f3323",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421171517,
-    "wof:lastmodified":1566588329,
+    "wof:lastmodified":1582358642,
     "wof:name":"Constitucion",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/171/527/421171527.geojson
+++ b/data/421/171/527/421171527.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008897,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0fdd17d990e56262f501f32348242133",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421171527,
-    "wof:lastmodified":1566588330,
+    "wof:lastmodified":1582358642,
     "wof:name":"Rio Senguer",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/171/529/421171529.geojson
+++ b/data/421/171/529/421171529.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008897,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c155263fb83ad9bea234bbb5a6c04ffa",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421171529,
-    "wof:lastmodified":1566588331,
+    "wof:lastmodified":1582358643,
     "wof:name":"Sarmiento",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/171/555/421171555.geojson
+++ b/data/421/171/555/421171555.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"537953e7d912c839f80a4299153a08aa",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421171555,
-    "wof:lastmodified":1566588332,
+    "wof:lastmodified":1582358643,
     "wof:name":"Ledesma",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/171/873/421171873.geojson
+++ b/data/421/171/873/421171873.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008910,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5230a65e952c0ba43fb02a0e69de85c6",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421171873,
-    "wof:lastmodified":1566588325,
+    "wof:lastmodified":1582358641,
     "wof:name":"Corralito",
     "wof:parent_id":421202253,
     "wof:placetype":"locality",

--- a/data/421/171/891/421171891.geojson
+++ b/data/421/171/891/421171891.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008911,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"377f74ba91785026b7a7b363cf6a5c96",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421171891,
-    "wof:lastmodified":1566588337,
+    "wof:lastmodified":1582358644,
     "wof:name":"San Cosme",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/171/949/421171949.geojson
+++ b/data/421/171/949/421171949.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008913,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f2bb089a282496008b1f1ac1ff3cd88",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421171949,
-    "wof:lastmodified":1566588331,
+    "wof:lastmodified":1582358643,
     "wof:name":"Guaymallen",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/172/041/421172041.geojson
+++ b/data/421/172/041/421172041.geojson
@@ -223,6 +223,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008917,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0fb6f5880a3d1fea6ad115fd9bebbc65",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
         }
     ],
     "wof:id":421172041,
-    "wof:lastmodified":1566588202,
+    "wof:lastmodified":1582358632,
     "wof:name":"Chilecito",
     "wof:parent_id":421202261,
     "wof:placetype":"locality",

--- a/data/421/172/183/421172183.geojson
+++ b/data/421/172/183/421172183.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008926,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e06ce2316f579c70ffae482da21dd19",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421172183,
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582358632,
     "wof:name":"Rawson",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/172/339/421172339.geojson
+++ b/data/421/172/339/421172339.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008931,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"18ffd39e8c4b1d2a999ed0b0f3dbfad7",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421172339,
-    "wof:lastmodified":1566588201,
+    "wof:lastmodified":1582358632,
     "wof:name":"San Antonio Oeste",
     "wof:parent_id":1108718395,
     "wof:placetype":"locality",

--- a/data/421/172/497/421172497.geojson
+++ b/data/421/172/497/421172497.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00db693269d698336d43230e0a7c54ea",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421172497,
-    "wof:lastmodified":1566588203,
+    "wof:lastmodified":1582358632,
     "wof:name":"Cruz Alta",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/172/581/421172581.geojson
+++ b/data/421/172/581/421172581.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008947,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f92324f000aceaf985442a05e5df8d80",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421172581,
-    "wof:lastmodified":1566588204,
+    "wof:lastmodified":1582358632,
     "wof:name":"Diamante",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/172/583/421172583.geojson
+++ b/data/421/172/583/421172583.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008947,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"228c86309087796e270984f3648fa98f",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421172583,
-    "wof:lastmodified":1566588208,
+    "wof:lastmodified":1582358632,
     "wof:name":"Valle Fertil",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/173/247/421173247.geojson
+++ b/data/421/173/247/421173247.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008976,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f70b61feb1bfeaa669a4c9b82b6f7227",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421173247,
-    "wof:lastmodified":1566588193,
+    "wof:lastmodified":1582358630,
     "wof:name":"Libertad",
     "wof:parent_id":85668063,
     "wof:placetype":"county",

--- a/data/421/173/249/421173249.geojson
+++ b/data/421/173/249/421173249.geojson
@@ -340,6 +340,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008976,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af052f1df06449cc3fbda0f32cc16ae4",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         }
     ],
     "wof:id":421173249,
-    "wof:lastmodified":1566588194,
+    "wof:lastmodified":1582358630,
     "wof:name":"Juan Bautista Alberdi",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/173/251/421173251.geojson
+++ b/data/421/173/251/421173251.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459008976,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"744a034073720e549a711df31c071acc",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421173251,
-    "wof:lastmodified":1566588191,
+    "wof:lastmodified":1582358630,
     "wof:name":"La Cocha",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/173/921/421173921.geojson
+++ b/data/421/173/921/421173921.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009011,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"365266476ed00a45c3ff2a423911443c",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421173921,
-    "wof:lastmodified":1566588194,
+    "wof:lastmodified":1582358630,
     "wof:name":"Rivadavia",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/174/285/421174285.geojson
+++ b/data/421/174/285/421174285.geojson
@@ -786,6 +786,9 @@
     ],
     "wof:country":"AR",
     "wof:created":1459009026,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa4b9f8e19f98ba1654e26398ce3cdc9",
     "wof:hierarchy":[
         {
@@ -796,7 +799,7 @@
         }
     ],
     "wof:id":421174285,
-    "wof:lastmodified":1566588180,
+    "wof:lastmodified":1582358628,
     "wof:name":"Buenos Aires",
     "wof:parent_id":85668081,
     "wof:placetype":"locality",

--- a/data/421/174/411/421174411.geojson
+++ b/data/421/174/411/421174411.geojson
@@ -194,6 +194,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009031,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"7db523a10d08ef081a8a499eaea596f9",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":421174411,
-    "wof:lastmodified":1566588180,
+    "wof:lastmodified":1582358628,
     "wof:name":"Chamical",
     "wof:parent_id":1108718327,
     "wof:placetype":"locality",

--- a/data/421/174/419/421174419.geojson
+++ b/data/421/174/419/421174419.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009032,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7d63e13a04e94faca8ed1bbebc72ec2",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421174419,
-    "wof:lastmodified":1566588178,
+    "wof:lastmodified":1582358628,
     "wof:name":"Yavi",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/174/423/421174423.geojson
+++ b/data/421/174/423/421174423.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009032,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2eab29b194d72b82e3e3dfdf8d0308a",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421174423,
-    "wof:lastmodified":1566588175,
+    "wof:lastmodified":1582358628,
     "wof:name":"Rinconada",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/174/843/421174843.geojson
+++ b/data/421/174/843/421174843.geojson
@@ -208,6 +208,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009046,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"1746dd1bce20f6e8ca3d359c8dab6777",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":421174843,
-    "wof:lastmodified":1566588175,
+    "wof:lastmodified":1582358628,
     "wof:name":"Humahuaca",
     "wof:parent_id":421204061,
     "wof:placetype":"locality",

--- a/data/421/174/889/421174889.geojson
+++ b/data/421/174/889/421174889.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009047,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff597414399ef3929ff01bf231221ef5",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":421174889,
-    "wof:lastmodified":1566588174,
+    "wof:lastmodified":1582358628,
     "wof:name":"Versailles",
     "wof:parent_id":1109371871,
     "wof:placetype":"neighbourhood",

--- a/data/421/175/153/421175153.geojson
+++ b/data/421/175/153/421175153.geojson
@@ -307,6 +307,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce92fbb0203efcd965e78222e8853533",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         }
     ],
     "wof:id":421175153,
-    "wof:lastmodified":1566588224,
+    "wof:lastmodified":1582358634,
     "wof:name":"Rio Grande",
     "wof:parent_id":85667995,
     "wof:placetype":"county",

--- a/data/421/175/285/421175285.geojson
+++ b/data/421/175/285/421175285.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009062,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6258f6651290db843f828a6c1553955d",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421175285,
-    "wof:lastmodified":1566588226,
+    "wof:lastmodified":1582358634,
     "wof:name":"Maraco",
     "wof:parent_id":85668019,
     "wof:placetype":"county",

--- a/data/421/175/287/421175287.geojson
+++ b/data/421/175/287/421175287.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009062,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17d0b3afae5d40bcfe8cc37f11ca07a7",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421175287,
-    "wof:lastmodified":1566588223,
+    "wof:lastmodified":1582358634,
     "wof:name":"General Jose De San Martin",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/175/289/421175289.geojson
+++ b/data/421/175/289/421175289.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009062,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6321c40604a2833250ba18612fac8d8c",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421175289,
-    "wof:lastmodified":1566588223,
+    "wof:lastmodified":1582358634,
     "wof:name":"Lules",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/175/299/421175299.geojson
+++ b/data/421/175/299/421175299.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009062,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"949bd6269028a58fdec5e6848f99874c",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421175299,
-    "wof:lastmodified":1566588227,
+    "wof:lastmodified":1582358634,
     "wof:name":"Lacar",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/175/301/421175301.geojson
+++ b/data/421/175/301/421175301.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009062,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4eeff533cbc69b87c3c222f94f8eafbf",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421175301,
-    "wof:lastmodified":1566588222,
+    "wof:lastmodified":1582358633,
     "wof:name":"Langui\u00f1eo",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/175/303/421175303.geojson
+++ b/data/421/175/303/421175303.geojson
@@ -187,6 +187,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009062,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"118af38d6c92c756f2a2e244f4804cbf",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":421175303,
-    "wof:lastmodified":1566588225,
+    "wof:lastmodified":1582358634,
     "wof:name":"Guarani",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/175/465/421175465.geojson
+++ b/data/421/175/465/421175465.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009068,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"b025ecb6d530d8ca69a2d56e18c94a63",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         }
     ],
     "wof:id":421175465,
-    "wof:lastmodified":1561793246,
+    "wof:lastmodified":1582358634,
     "wof:name":"Uspallata",
     "wof:parent_id":421170121,
     "wof:placetype":"locality",

--- a/data/421/176/599/421176599.geojson
+++ b/data/421/176/599/421176599.geojson
@@ -196,6 +196,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009113,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"3979d3e0a093f06286dfd35085f531b8",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":421176599,
-    "wof:lastmodified":1561793261,
+    "wof:lastmodified":1582358641,
     "wof:name":"Abra Pampa",
     "wof:parent_id":421185367,
     "wof:placetype":"locality",

--- a/data/421/177/929/421177929.geojson
+++ b/data/421/177/929/421177929.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009165,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c23376c4f1146791948229836b5ec129",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421177929,
-    "wof:lastmodified":1566588304,
+    "wof:lastmodified":1582358640,
     "wof:name":"Trenel",
     "wof:parent_id":85668019,
     "wof:placetype":"county",

--- a/data/421/177/957/421177957.geojson
+++ b/data/421/177/957/421177957.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009166,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30eae13fa09d384627ecde359a0cf91b",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421177957,
-    "wof:lastmodified":1566588303,
+    "wof:lastmodified":1582358640,
     "wof:name":"Toay",
     "wof:parent_id":85668019,
     "wof:placetype":"county",

--- a/data/421/177/961/421177961.geojson
+++ b/data/421/177/961/421177961.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009166,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"616bf9beecb3d9ce7b73e0945a446879",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421177961,
-    "wof:lastmodified":1566588303,
+    "wof:lastmodified":1582358640,
     "wof:name":"San Javier",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/178/317/421178317.geojson
+++ b/data/421/178/317/421178317.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009178,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7b9eb35b0410cdc61f132a7e0e8ec6e",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421178317,
-    "wof:lastmodified":1566588316,
+    "wof:lastmodified":1582358641,
     "wof:name":"Chicligasta",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/178/989/421178989.geojson
+++ b/data/421/178/989/421178989.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009200,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"d33726714afff494ce2e3655e57b170b",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421178989,
-    "wof:lastmodified":1566588315,
+    "wof:lastmodified":1582358641,
     "wof:name":"Choele Choel",
     "wof:parent_id":1108718387,
     "wof:placetype":"locality",

--- a/data/421/179/647/421179647.geojson
+++ b/data/421/179/647/421179647.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009228,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bfde8d2a4eb862231f1931c716db5b3",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421179647,
-    "wof:lastmodified":1566588311,
+    "wof:lastmodified":1582358640,
     "wof:name":"Lanus",
     "wof:parent_id":85668015,
     "wof:placetype":"county",

--- a/data/421/180/187/421180187.geojson
+++ b/data/421/180/187/421180187.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009247,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03ba0c60e4b21804dc13db1501e70bf9",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421180187,
-    "wof:lastmodified":1566588185,
+    "wof:lastmodified":1582358629,
     "wof:name":"Montecarlo",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/180/291/421180291.geojson
+++ b/data/421/180/291/421180291.geojson
@@ -261,6 +261,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009251,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2eecc26daa9f4bb283d7eaeb700ecd23",
     "wof:hierarchy":[
         {
@@ -271,7 +274,7 @@
         }
     ],
     "wof:id":421180291,
-    "wof:lastmodified":1566588187,
+    "wof:lastmodified":1582358629,
     "wof:name":"Formosa",
     "wof:parent_id":85668067,
     "wof:placetype":"county",

--- a/data/421/180/295/421180295.geojson
+++ b/data/421/180/295/421180295.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009251,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dc5f734807198e18e7045a98e5ef81c",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":421180295,
-    "wof:lastmodified":1566588185,
+    "wof:lastmodified":1582358629,
     "wof:name":"San Fernando",
     "wof:parent_id":85668063,
     "wof:placetype":"county",

--- a/data/421/180/297/421180297.geojson
+++ b/data/421/180/297/421180297.geojson
@@ -147,6 +147,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009251,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2231e28014fa7cb9b4e6bb41720dbe7f",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":421180297,
-    "wof:lastmodified":1566588187,
+    "wof:lastmodified":1582358629,
     "wof:name":"San Ignacio",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/180/301/421180301.geojson
+++ b/data/421/180/301/421180301.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009251,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e5232b59cb64c91e6bc243191187e84",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421180301,
-    "wof:lastmodified":1566588184,
+    "wof:lastmodified":1582358629,
     "wof:name":"Rosario De Lerma",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/180/885/421180885.geojson
+++ b/data/421/180/885/421180885.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009274,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29e2a8fb1415dfb8ef04d00176fb06f9",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421180885,
-    "wof:lastmodified":1566588186,
+    "wof:lastmodified":1582358629,
     "wof:name":"Las Colonias",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/180/887/421180887.geojson
+++ b/data/421/180/887/421180887.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009274,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"391ffe14dd2eed2aa742326c133b11f5",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":421180887,
-    "wof:lastmodified":1566588184,
+    "wof:lastmodified":1582358629,
     "wof:name":"Capital",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/181/141/421181141.geojson
+++ b/data/421/181/141/421181141.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009286,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"3aa02537773f7e8cc2b44d6b9a77a70e",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421181141,
-    "wof:lastmodified":1561793245,
+    "wof:lastmodified":1582358633,
     "wof:name":"Villa Rumipal",
     "wof:parent_id":421186303,
     "wof:placetype":"locality",

--- a/data/421/181/251/421181251.geojson
+++ b/data/421/181/251/421181251.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009290,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c66ecd5b3496ee2d31b681f36af2b75",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421181251,
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582358633,
     "wof:name":"Santa Victoria",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/181/665/421181665.geojson
+++ b/data/421/181/665/421181665.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009303,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"73b51fa8a466f086a10b091e6783b488",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421181665,
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582358633,
     "wof:name":"Hucal",
     "wof:parent_id":85668019,
     "wof:placetype":"county",

--- a/data/421/181/861/421181861.geojson
+++ b/data/421/181/861/421181861.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009309,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9052a50ff2148d965650aa0e0fe1a289",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421181861,
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582358633,
     "wof:name":"Arauco",
     "wof:parent_id":85668045,
     "wof:placetype":"county",

--- a/data/421/181/877/421181877.geojson
+++ b/data/421/181/877/421181877.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009309,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b161f4ebb7c5c79a147c3aa7b749cbd7",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":421181877,
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582358633,
     "wof:name":"Federacion",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/181/879/421181879.geojson
+++ b/data/421/181/879/421181879.geojson
@@ -438,6 +438,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009310,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"095e9e8ce1aa46a18e8ffecb638107ef",
     "wof:hierarchy":[
         {
@@ -448,7 +451,7 @@
         }
     ],
     "wof:id":421181879,
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582358633,
     "wof:name":"La Paz",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/181/881/421181881.geojson
+++ b/data/421/181/881/421181881.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009311,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1107e6ebd88e3695ddb84d251d2f6cfa",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421181881,
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582358633,
     "wof:name":"Chapaleufu",
     "wof:parent_id":85668019,
     "wof:placetype":"county",

--- a/data/421/181/953/421181953.geojson
+++ b/data/421/181/953/421181953.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009313,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"cf8cc184367ced93a3dcde821b5b5f0d",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":421181953,
-    "wof:lastmodified":1566588217,
+    "wof:lastmodified":1582358633,
     "wof:name":"Vera",
     "wof:parent_id":1108718463,
     "wof:placetype":"locality",

--- a/data/421/182/717/421182717.geojson
+++ b/data/421/182/717/421182717.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009339,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9cae7de51dfbef20a226e1049ef50ce7",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421182717,
-    "wof:lastmodified":1566588319,
+    "wof:lastmodified":1582358641,
     "wof:name":"General Alvear",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/182/825/421182825.geojson
+++ b/data/421/182/825/421182825.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009348,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c33aa98c9280c175a2b6a77563081bb8",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421182825,
-    "wof:lastmodified":1566588318,
+    "wof:lastmodified":1582358641,
     "wof:name":"Famailla",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/182/827/421182827.geojson
+++ b/data/421/182/827/421182827.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009348,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa1fc17d2350e7a06b978db08fc51945",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421182827,
-    "wof:lastmodified":1566588316,
+    "wof:lastmodified":1582358641,
     "wof:name":"Simoca",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/183/163/421183163.geojson
+++ b/data/421/183/163/421183163.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009360,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ca38454563478dae7cb91846408c214",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421183163,
-    "wof:lastmodified":1566588308,
+    "wof:lastmodified":1582358640,
     "wof:name":"Cainguas",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/183/183/421183183.geojson
+++ b/data/421/183/183/421183183.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009361,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"486671000f06c708d21ca2a520f8231e",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421183183,
-    "wof:lastmodified":1566588310,
+    "wof:lastmodified":1582358640,
     "wof:name":"General Jos\u00e9 de San Mart\u00edn",
     "wof:parent_id":421198477,
     "wof:placetype":"locality",

--- a/data/421/183/345/421183345.geojson
+++ b/data/421/183/345/421183345.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009366,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"969f5c2306f2795bbb63a72441625c41",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421183345,
-    "wof:lastmodified":1566588310,
+    "wof:lastmodified":1582358640,
     "wof:name":"General Obligado",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/183/349/421183349.geojson
+++ b/data/421/183/349/421183349.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009366,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb158e82030d9f777c44d7d727f67da5",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421183349,
-    "wof:lastmodified":1566588306,
+    "wof:lastmodified":1582358640,
     "wof:name":"Lago Argentino",
     "wof:parent_id":85667991,
     "wof:placetype":"county",

--- a/data/421/183/625/421183625.geojson
+++ b/data/421/183/625/421183625.geojson
@@ -187,6 +187,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009376,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"f86ad1d40709818df9ca31325d370097",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
         }
     ],
     "wof:id":421183625,
-    "wof:lastmodified":1561793259,
+    "wof:lastmodified":1582358640,
     "wof:name":"Las Lajas",
     "wof:parent_id":421202309,
     "wof:placetype":"locality",

--- a/data/421/183/901/421183901.geojson
+++ b/data/421/183/901/421183901.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009391,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e82b9960f41f9eca7b2f13c54ae6be6",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421183901,
-    "wof:lastmodified":1566588305,
+    "wof:lastmodified":1582358640,
     "wof:name":"Monteros",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/183/903/421183903.geojson
+++ b/data/421/183/903/421183903.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009391,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b87ad34b519b0d35f1d1016d67758069",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421183903,
-    "wof:lastmodified":1566588308,
+    "wof:lastmodified":1582358640,
     "wof:name":"Metan",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/184/161/421184161.geojson
+++ b/data/421/184/161/421184161.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009402,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3cca41d8c8025f3d0f5de86b6eab2661",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":421184161,
-    "wof:lastmodified":1566588289,
+    "wof:lastmodified":1582358638,
     "wof:name":"Banda",
     "wof:parent_id":85668053,
     "wof:placetype":"county",

--- a/data/421/184/163/421184163.geojson
+++ b/data/421/184/163/421184163.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009402,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c7997a86100a013336c5d703b3b9dffe",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421184163,
-    "wof:lastmodified":1566588292,
+    "wof:lastmodified":1582358638,
     "wof:name":"Aguirre",
     "wof:parent_id":85668053,
     "wof:placetype":"county",

--- a/data/421/184/329/421184329.geojson
+++ b/data/421/184/329/421184329.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009407,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89a847c3195055d804119b87582b594f",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421184329,
-    "wof:lastmodified":1566588294,
+    "wof:lastmodified":1582358638,
     "wof:name":"9 De Julio",
     "wof:parent_id":85668025,
     "wof:placetype":"county",

--- a/data/421/184/501/421184501.geojson
+++ b/data/421/184/501/421184501.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009412,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d183ceb5b081c96b148b813285424275",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421184501,
-    "wof:lastmodified":1566588292,
+    "wof:lastmodified":1582358638,
     "wof:name":"Chimbas",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/185/059/421185059.geojson
+++ b/data/421/185/059/421185059.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78e112bc15a31e38cd8170170c06bd9d",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421185059,
-    "wof:lastmodified":1566588346,
+    "wof:lastmodified":1582358645,
     "wof:name":"Independencia",
     "wof:parent_id":85668063,
     "wof:placetype":"county",

--- a/data/421/185/061/421185061.geojson
+++ b/data/421/185/061/421185061.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef76c002fa85a284a686926c92a25de0",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421185061,
-    "wof:lastmodified":1566588346,
+    "wof:lastmodified":1582358645,
     "wof:name":"Fray Mamerto Esquiu",
     "wof:parent_id":85668035,
     "wof:placetype":"county",

--- a/data/421/185/063/421185063.geojson
+++ b/data/421/185/063/421185063.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a47f04bbca8098309e78ee70759fdbbe",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421185063,
-    "wof:lastmodified":1566588343,
+    "wof:lastmodified":1582358644,
     "wof:name":"Bermejo",
     "wof:parent_id":85668063,
     "wof:placetype":"county",

--- a/data/421/185/323/421185323.geojson
+++ b/data/421/185/323/421185323.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e33e6f30aab29599e3a21dcfad3cf7a",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":421185323,
-    "wof:lastmodified":1566588344,
+    "wof:lastmodified":1582358645,
     "wof:name":"Magallanes",
     "wof:parent_id":85667991,
     "wof:placetype":"county",

--- a/data/421/185/367/421185367.geojson
+++ b/data/421/185/367/421185367.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009441,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f578c548c532a6374228e7ff6dea4702",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421185367,
-    "wof:lastmodified":1566588344,
+    "wof:lastmodified":1582358645,
     "wof:name":"Cochinoca",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/185/417/421185417.geojson
+++ b/data/421/185/417/421185417.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009442,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51caef65bce215fa07b8d8c81b64c5f3",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421185417,
-    "wof:lastmodified":1566588345,
+    "wof:lastmodified":1582358645,
     "wof:name":"Itati",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/185/419/421185419.geojson
+++ b/data/421/185/419/421185419.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009442,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d00f9ed34f37360768b3daa99d149c15",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421185419,
-    "wof:lastmodified":1566588345,
+    "wof:lastmodified":1582358645,
     "wof:name":"Almirante Brown",
     "wof:parent_id":85668063,
     "wof:placetype":"county",

--- a/data/421/185/481/421185481.geojson
+++ b/data/421/185/481/421185481.geojson
@@ -263,6 +263,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86701b4c69e64281f7a25631e53855dc",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         }
     ],
     "wof:id":421185481,
-    "wof:lastmodified":1566588345,
+    "wof:lastmodified":1582358645,
     "wof:name":"Rio Cuarto",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/185/485/421185485.geojson
+++ b/data/421/185/485/421185485.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28d5de515a80c7e9769c5ced2ed539b3",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421185485,
-    "wof:lastmodified":1566588342,
+    "wof:lastmodified":1582358644,
     "wof:name":"Collon Cura",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/185/855/421185855.geojson
+++ b/data/421/185/855/421185855.geojson
@@ -349,6 +349,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009456,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d07f17b1304df04930d48729f163c1e",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         }
     ],
     "wof:id":421185855,
-    "wof:lastmodified":1566588346,
+    "wof:lastmodified":1582358645,
     "wof:name":"San Salvador de Jujuy",
     "wof:parent_id":421169781,
     "wof:placetype":"locality",

--- a/data/421/186/089/421186089.geojson
+++ b/data/421/186/089/421186089.geojson
@@ -243,6 +243,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009464,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"fc9c7e447377d202d239dd8351b1680f",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
         }
     ],
     "wof:id":421186089,
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582358633,
     "wof:name":"Mercedes",
     "wof:parent_id":421203353,
     "wof:placetype":"locality",

--- a/data/421/186/135/421186135.geojson
+++ b/data/421/186/135/421186135.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009471,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b7606fb2096ae0da8b0bdb448f16998",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421186135,
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582358632,
     "wof:name":"General San Martin",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/186/207/421186207.geojson
+++ b/data/421/186/207/421186207.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009473,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2351518a5395ca1dac8a9609eb92c2e3",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421186207,
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582358633,
     "wof:name":"Adolfo Alsina",
     "wof:parent_id":85668025,
     "wof:placetype":"county",

--- a/data/421/186/297/421186297.geojson
+++ b/data/421/186/297/421186297.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58bc6bad9ea08438f6ad3ea9575da388",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421186297,
-    "wof:lastmodified":1566588215,
+    "wof:lastmodified":1582358633,
     "wof:name":"Tafi Del Valle",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/186/299/421186299.geojson
+++ b/data/421/186/299/421186299.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1439d354cb87313d1e1d055b51c1a0cb",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421186299,
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582358633,
     "wof:name":"La Poma",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/186/301/421186301.geojson
+++ b/data/421/186/301/421186301.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4125620987002e7e6c6904f6af069e4f",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":421186301,
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582358632,
     "wof:name":"Santa Maria",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/186/303/421186303.geojson
+++ b/data/421/186/303/421186303.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd330da8b7831cd03e6b237ee82c61df",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421186303,
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582358632,
     "wof:name":"Calamuchita",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/186/305/421186305.geojson
+++ b/data/421/186/305/421186305.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"032390daca7ccbe3515837f7c049effc",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421186305,
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582358632,
     "wof:name":"Los Lagos",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/186/443/421186443.geojson
+++ b/data/421/186/443/421186443.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009481,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97e1014b87e9ea021ed32f2e485fa27b",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421186443,
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582358633,
     "wof:name":"Rio Hondo",
     "wof:parent_id":85668053,
     "wof:placetype":"county",

--- a/data/421/186/901/421186901.geojson
+++ b/data/421/186/901/421186901.geojson
@@ -178,6 +178,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009495,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"c155f9df7bdd46afb752c9e3d1d45c26",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":421186901,
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582358632,
     "wof:name":"Susques",
     "wof:parent_id":421171265,
     "wof:placetype":"locality",

--- a/data/421/186/917/421186917.geojson
+++ b/data/421/186/917/421186917.geojson
@@ -231,6 +231,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009496,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d897ab61dea1a8304046dba6701bda40",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         }
     ],
     "wof:id":421186917,
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582358633,
     "wof:name":"Viedma",
     "wof:parent_id":421186207,
     "wof:placetype":"locality",

--- a/data/421/187/151/421187151.geojson
+++ b/data/421/187/151/421187151.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009503,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dadf3e2190681611d3289d9f968f5ddc",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421187151,
-    "wof:lastmodified":1566588188,
+    "wof:lastmodified":1582358629,
     "wof:name":"La Caldera",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/187/689/421187689.geojson
+++ b/data/421/187/689/421187689.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009521,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7c7131abf6ca7164fba1d222a3e4011",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421187689,
-    "wof:lastmodified":1566588188,
+    "wof:lastmodified":1582358630,
     "wof:name":"Maipu",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/187/691/421187691.geojson
+++ b/data/421/187/691/421187691.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009521,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ec05b6754a1e25939309b15c6af1cb9",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421187691,
-    "wof:lastmodified":1566588189,
+    "wof:lastmodified":1582358630,
     "wof:name":"Lavalle",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/188/015/421188015.geojson
+++ b/data/421/188/015/421188015.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009531,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f04134d718e45efaba4d03060dfaf43c",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421188015,
-    "wof:lastmodified":1566588197,
+    "wof:lastmodified":1582358630,
     "wof:name":"San Jeronimo",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/188/023/421188023.geojson
+++ b/data/421/188/023/421188023.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009531,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d23099497c2117e49ef734081b6cb470",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421188023,
-    "wof:lastmodified":1566588196,
+    "wof:lastmodified":1582358630,
     "wof:name":"Tres De Febrero",
     "wof:parent_id":85668015,
     "wof:placetype":"county",

--- a/data/421/188/041/421188041.geojson
+++ b/data/421/188/041/421188041.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79e187fd4717018780a40e189c6829c9",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421188041,
-    "wof:lastmodified":1566588197,
+    "wof:lastmodified":1582358630,
     "wof:name":"General Roca",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/188/043/421188043.geojson
+++ b/data/421/188/043/421188043.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02e87940c74322d8f5e4b8b26b24a263",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421188043,
-    "wof:lastmodified":1566588199,
+    "wof:lastmodified":1582358631,
     "wof:name":"Malarg\u00fce",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/188/045/421188045.geojson
+++ b/data/421/188/045/421188045.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ce7af3e814b26c2fe72e15df58a24da",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421188045,
-    "wof:lastmodified":1566588198,
+    "wof:lastmodified":1582358631,
     "wof:name":"San Rafael",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/188/059/421188059.geojson
+++ b/data/421/188/059/421188059.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c50824c9ffa4ddd5e2f83b47385b6f2",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421188059,
-    "wof:lastmodified":1566588200,
+    "wof:lastmodified":1582358632,
     "wof:name":"Alumine",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/188/061/421188061.geojson
+++ b/data/421/188/061/421188061.geojson
@@ -223,6 +223,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"900a0961cbe1881fe1009d450887388d",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         }
     ],
     "wof:id":421188061,
-    "wof:lastmodified":1566588200,
+    "wof:lastmodified":1582358631,
     "wof:name":"Bariloche",
     "wof:parent_id":85668025,
     "wof:placetype":"county",

--- a/data/421/188/063/421188063.geojson
+++ b/data/421/188/063/421188063.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009533,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8762427d579fae488002543ba074f9e",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421188063,
-    "wof:lastmodified":1566588197,
+    "wof:lastmodified":1582358631,
     "wof:name":"Pilcaniyeu",
     "wof:parent_id":85668025,
     "wof:placetype":"county",

--- a/data/421/188/213/421188213.geojson
+++ b/data/421/188/213/421188213.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009538,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3f0e2c989966ca1941c0abd3ad0b7a0",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421188213,
-    "wof:lastmodified":1566588199,
+    "wof:lastmodified":1582358631,
     "wof:name":"Lihuel Calel",
     "wof:parent_id":85668019,
     "wof:placetype":"county",

--- a/data/421/189/001/421189001.geojson
+++ b/data/421/189/001/421189001.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009596,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb0a6b9536868e9ff5869768938e9c38",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421189001,
-    "wof:lastmodified":1566588195,
+    "wof:lastmodified":1582358630,
     "wof:name":"Junin",
     "wof:parent_id":85668029,
     "wof:placetype":"county",

--- a/data/421/189/009/421189009.geojson
+++ b/data/421/189/009/421189009.geojson
@@ -293,6 +293,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009596,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e8c5e9d1c3f242881396ab30503ac07",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         }
     ],
     "wof:id":421189009,
-    "wof:lastmodified":1566588195,
+    "wof:lastmodified":1582358630,
     "wof:name":"Victoria",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/189/013/421189013.geojson
+++ b/data/421/189/013/421189013.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009601,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d1eb5c71313ea00a2f6b33905a01a75",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421189013,
-    "wof:lastmodified":1566588195,
+    "wof:lastmodified":1582358630,
     "wof:name":"Valle Viejo",
     "wof:parent_id":85668035,
     "wof:placetype":"county",

--- a/data/421/189/015/421189015.geojson
+++ b/data/421/189/015/421189015.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009601,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf3e9e0d3bc77e074d5344fd79267aff",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421189015,
-    "wof:lastmodified":1566588195,
+    "wof:lastmodified":1582358630,
     "wof:name":"Rio Primero",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/189/019/421189019.geojson
+++ b/data/421/189/019/421189019.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009602,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5ba594d58232c36c5640ab7a42f12a1",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421189019,
-    "wof:lastmodified":1566588195,
+    "wof:lastmodified":1582358630,
     "wof:name":"Empedrado",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/189/963/421189963.geojson
+++ b/data/421/189/963/421189963.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009642,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36b9900b1af6343bdc590723017ab64a",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421189963,
-    "wof:lastmodified":1566588194,
+    "wof:lastmodified":1582358630,
     "wof:name":"San Martin",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/191/005/421191005.geojson
+++ b/data/421/191/005/421191005.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe91fd19b8f2621c2afae451a718ab9d",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421191005,
-    "wof:lastmodified":1566588268,
+    "wof:lastmodified":1582358636,
     "wof:name":"Paclin",
     "wof:parent_id":85668035,
     "wof:placetype":"county",

--- a/data/421/191/007/421191007.geojson
+++ b/data/421/191/007/421191007.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"226ffcb0ac90411bedd9f108c03d4d09",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191007,
-    "wof:lastmodified":1566588261,
+    "wof:lastmodified":1582358636,
     "wof:name":"Esquina",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/191/011/421191011.geojson
+++ b/data/421/191/011/421191011.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"801fb44986fadd723d729d7e26ed0bdf",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421191011,
-    "wof:lastmodified":1566588266,
+    "wof:lastmodified":1582358636,
     "wof:name":"General Guemes",
     "wof:parent_id":85668063,
     "wof:placetype":"county",

--- a/data/421/191/013/421191013.geojson
+++ b/data/421/191/013/421191013.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1677e7005a48fc3c4d433cba064b513",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421191013,
-    "wof:lastmodified":1566588260,
+    "wof:lastmodified":1582358636,
     "wof:name":"Monte Caseros",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/191/015/421191015.geojson
+++ b/data/421/191/015/421191015.geojson
@@ -153,6 +153,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3981a1af17a4c62675f8fb9bac31aa1a",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":421191015,
-    "wof:lastmodified":1566588259,
+    "wof:lastmodified":1582358636,
     "wof:name":"Bella Vista",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/191/017/421191017.geojson
+++ b/data/421/191/017/421191017.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f515afa72656717ca6cf21b0f3df585d",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421191017,
-    "wof:lastmodified":1566588266,
+    "wof:lastmodified":1582358636,
     "wof:name":"San Roque",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/191/021/421191021.geojson
+++ b/data/421/191/021/421191021.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d991236b5dc15d17a4b4296b9f27b250",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421191021,
-    "wof:lastmodified":1566588267,
+    "wof:lastmodified":1582358636,
     "wof:name":"Garay",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/191/183/421191183.geojson
+++ b/data/421/191/183/421191183.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009683,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48394aa19c303665c0f29c7a6b5bfe37",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421191183,
-    "wof:lastmodified":1566588269,
+    "wof:lastmodified":1582358636,
     "wof:name":"Cruz Del Eje",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/191/185/421191185.geojson
+++ b/data/421/191/185/421191185.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009683,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"034660ca22aac2b650d6f5bffe060e98",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421191185,
-    "wof:lastmodified":1566588269,
+    "wof:lastmodified":1582358636,
     "wof:name":"Zapala",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/191/195/421191195.geojson
+++ b/data/421/191/195/421191195.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009683,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ab5a5bfc4f062cff6db55a126f49252",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421191195,
-    "wof:lastmodified":1566588258,
+    "wof:lastmodified":1582358635,
     "wof:name":"Villa del Parque",
     "wof:parent_id":1109371873,
     "wof:placetype":"neighbourhood",

--- a/data/421/191/593/421191593.geojson
+++ b/data/421/191/593/421191593.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009698,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9daf27fe78fa0e73eafa917b0db1fb75",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421191593,
-    "wof:lastmodified":1566588257,
+    "wof:lastmodified":1582358635,
     "wof:name":"General G\u00fcemes",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/191/687/421191687.geojson
+++ b/data/421/191/687/421191687.geojson
@@ -227,6 +227,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009702,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0338fd33b23e0ad764c81081be3c767c",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
         }
     ],
     "wof:id":421191687,
-    "wof:lastmodified":1566588260,
+    "wof:lastmodified":1582358636,
     "wof:name":"Avellaneda",
     "wof:parent_id":85668015,
     "wof:placetype":"county",

--- a/data/421/191/805/421191805.geojson
+++ b/data/421/191/805/421191805.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009710,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ca8db7770a7aa0c00a989c78b22de3b",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421191805,
-    "wof:lastmodified":1566588262,
+    "wof:lastmodified":1582358636,
     "wof:name":"Tilcara",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/192/281/421192281.geojson
+++ b/data/421/192/281/421192281.geojson
@@ -210,6 +210,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009731,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"5bf63f730556aa10b11e682248276b9a",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":421192281,
-    "wof:lastmodified":1561793219,
+    "wof:lastmodified":1582358624,
     "wof:name":"Zapala",
     "wof:parent_id":421191185,
     "wof:placetype":"locality",

--- a/data/421/192/923/421192923.geojson
+++ b/data/421/192/923/421192923.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009753,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"798abb4120aec9e9dcb555a170230b9a",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421192923,
-    "wof:lastmodified":1566588120,
+    "wof:lastmodified":1582358624,
     "wof:name":"Minas",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/192/925/421192925.geojson
+++ b/data/421/192/925/421192925.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009753,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3e12614a421626ecddcf3ed1c6066b5",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421192925,
-    "wof:lastmodified":1566588120,
+    "wof:lastmodified":1582358624,
     "wof:name":"Pehuenches",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/192/961/421192961.geojson
+++ b/data/421/192/961/421192961.geojson
@@ -165,6 +165,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009755,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91afe147cd18a6efc999d23f4e214c1f",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421192961,
-    "wof:lastmodified":1566588120,
+    "wof:lastmodified":1582358624,
     "wof:name":"San Carlos",
     "wof:parent_id":421180885,
     "wof:placetype":"locality",

--- a/data/421/193/305/421193305.geojson
+++ b/data/421/193/305/421193305.geojson
@@ -196,6 +196,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009767,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"fe497e0d9e4c70de34bfbfd555b856ee",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":421193305,
-    "wof:lastmodified":1566588142,
+    "wof:lastmodified":1582358625,
     "wof:name":"Las Plumas",
     "wof:parent_id":421199905,
     "wof:placetype":"locality",

--- a/data/421/193/663/421193663.geojson
+++ b/data/421/193/663/421193663.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2959d7ce304d7d8899cc94267c4d899f",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421193663,
-    "wof:lastmodified":1566588142,
+    "wof:lastmodified":1582358625,
     "wof:name":"Goya",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/193/995/421193995.geojson
+++ b/data/421/193/995/421193995.geojson
@@ -363,6 +363,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009789,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4697831a939ce32cc7355aa80be666be",
     "wof:hierarchy":[
         {
@@ -374,7 +377,7 @@
         }
     ],
     "wof:id":421193995,
-    "wof:lastmodified":1566588141,
+    "wof:lastmodified":1582358624,
     "wof:name":"Neuqu\u00e9n",
     "wof:parent_id":421169777,
     "wof:placetype":"locality",

--- a/data/421/194/115/421194115.geojson
+++ b/data/421/194/115/421194115.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009794,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6611ef55331fc4737ab25fb04de9451",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421194115,
-    "wof:lastmodified":1566588138,
+    "wof:lastmodified":1582358624,
     "wof:name":"Colon",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/194/439/421194439.geojson
+++ b/data/421/194/439/421194439.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7318f921991bf3ec2e3ef4d891de27a2",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421194439,
-    "wof:lastmodified":1566588136,
+    "wof:lastmodified":1582358624,
     "wof:name":"Gualeguay",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/194/705/421194705.geojson
+++ b/data/421/194/705/421194705.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009817,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0d11374b8519c9b9849271bc2f9375f4",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421194705,
-    "wof:lastmodified":1561793227,
+    "wof:lastmodified":1582358624,
     "wof:name":"Esquel",
     "wof:parent_id":421170127,
     "wof:placetype":"locality",

--- a/data/421/194/777/421194777.geojson
+++ b/data/421/194/777/421194777.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009819,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b1b50d1145a2f6be290d1e568493fcc",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421194777,
-    "wof:lastmodified":1566588137,
+    "wof:lastmodified":1582358624,
     "wof:name":"Zonda",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/195/101/421195101.geojson
+++ b/data/421/195/101/421195101.geojson
@@ -196,6 +196,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009832,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"e505f6c53141829d77aef9ff02053df1",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":421195101,
-    "wof:lastmodified":1566588132,
+    "wof:lastmodified":1582358624,
     "wof:name":"Las Heras",
     "wof:parent_id":421170121,
     "wof:placetype":"locality",

--- a/data/421/195/477/421195477.geojson
+++ b/data/421/195/477/421195477.geojson
@@ -290,6 +290,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009849,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52ece8cd539b79ee9089716db4f226f1",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         }
     ],
     "wof:id":421195477,
-    "wof:lastmodified":1566588125,
+    "wof:lastmodified":1582358624,
     "wof:name":"Almafuerte",
     "wof:parent_id":421171465,
     "wof:placetype":"locality",

--- a/data/421/195/857/421195857.geojson
+++ b/data/421/195/857/421195857.geojson
@@ -189,6 +189,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009861,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b85e941fecf95839c064f7b631c31649",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":421195857,
-    "wof:lastmodified":1566588126,
+    "wof:lastmodified":1582358624,
     "wof:name":"San Carlos",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/196/069/421196069.geojson
+++ b/data/421/196/069/421196069.geojson
@@ -183,6 +183,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009868,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"e2496e47e43e094015b43935833f7166",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":421196069,
-    "wof:lastmodified":1561793252,
+    "wof:lastmodified":1582358635,
     "wof:name":"Cerrillos",
     "wof:parent_id":421171213,
     "wof:placetype":"locality",

--- a/data/421/196/363/421196363.geojson
+++ b/data/421/196/363/421196363.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009879,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"15912732fae40e1326503deb39baa731",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421196363,
-    "wof:lastmodified":1566588240,
+    "wof:lastmodified":1582358635,
     "wof:name":"Nueve de Julio",
     "wof:parent_id":1108718179,
     "wof:placetype":"locality",

--- a/data/421/196/385/421196385.geojson
+++ b/data/421/196/385/421196385.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009879,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"b8b06b6b1eb542bc0b9969187ccf3119",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421196385,
-    "wof:lastmodified":1534379081,
+    "wof:lastmodified":1582358635,
     "wof:name":"Rodeo",
     "wof:parent_id":421171511,
     "wof:placetype":"locality",

--- a/data/421/196/937/421196937.geojson
+++ b/data/421/196/937/421196937.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fcd12a652d5d25460e542c8e0d9ef033",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421196937,
-    "wof:lastmodified":1566588240,
+    "wof:lastmodified":1582358635,
     "wof:name":"Huiliches",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/196/953/421196953.geojson
+++ b/data/421/196/953/421196953.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd9fb2f4f33dc61724ae36818d0414d6",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421196953,
-    "wof:lastmodified":1566588239,
+    "wof:lastmodified":1582358635,
     "wof:name":"Rio Segundo",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/196/955/421196955.geojson
+++ b/data/421/196/955/421196955.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7741f226354738254e59cbc9336b9af6",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421196955,
-    "wof:lastmodified":1566588241,
+    "wof:lastmodified":1582358635,
     "wof:name":"Tulumba",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/197/043/421197043.geojson
+++ b/data/421/197/043/421197043.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37e6fd32b429e8a80f181b1cb3981b6f",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421197043,
-    "wof:lastmodified":1566588273,
+    "wof:lastmodified":1582358637,
     "wof:name":"Coronel Felipe Varela",
     "wof:parent_id":85668045,
     "wof:placetype":"county",

--- a/data/421/197/591/421197591.geojson
+++ b/data/421/197/591/421197591.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009919,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47a675fe0e7505473d19896d3b8873c8",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421197591,
-    "wof:lastmodified":1566588273,
+    "wof:lastmodified":1582358636,
     "wof:name":"Cafayate",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/197/593/421197593.geojson
+++ b/data/421/197/593/421197593.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009919,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aef638d5bbe7ca343b99f44f2dc72e8a",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421197593,
-    "wof:lastmodified":1566588270,
+    "wof:lastmodified":1582358636,
     "wof:name":"Molinos",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/198/213/421198213.geojson
+++ b/data/421/198/213/421198213.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009940,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bcd7b284621d8d4917d4772639d5214c",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":421198213,
-    "wof:lastmodified":1566588236,
+    "wof:lastmodified":1582358635,
     "wof:name":"San Miguel",
     "wof:parent_id":421172497,
     "wof:placetype":"locality",

--- a/data/421/198/377/421198377.geojson
+++ b/data/421/198/377/421198377.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009946,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"405328b50ae2063eecf7a2b9cec62206",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421198377,
-    "wof:lastmodified":1566588232,
+    "wof:lastmodified":1582358634,
     "wof:name":"Albardon",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/198/469/421198469.geojson
+++ b/data/421/198/469/421198469.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6a62e00c26d27338e8b3f245707e5b5",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421198469,
-    "wof:lastmodified":1566588236,
+    "wof:lastmodified":1582358635,
     "wof:name":"Godoy Cruz",
     "wof:parent_id":85668007,
     "wof:placetype":"county",

--- a/data/421/198/471/421198471.geojson
+++ b/data/421/198/471/421198471.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2cf8aa1e20a501f7edaa5e8434be2d82",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421198471,
-    "wof:lastmodified":1566588230,
+    "wof:lastmodified":1582358634,
     "wof:name":"Iguazu",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/198/473/421198473.geojson
+++ b/data/421/198/473/421198473.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ea13f53a747e60cfe715235f1c7a3de",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421198473,
-    "wof:lastmodified":1566588236,
+    "wof:lastmodified":1582358635,
     "wof:name":"Obera",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/198/475/421198475.geojson
+++ b/data/421/198/475/421198475.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c105e53087e9588e07f02a753da1539c",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421198475,
-    "wof:lastmodified":1566588235,
+    "wof:lastmodified":1582358635,
     "wof:name":"San Alberto",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/198/477/421198477.geojson
+++ b/data/421/198/477/421198477.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab0983bff9b555514eb90fb6b148c718",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421198477,
-    "wof:lastmodified":1566588230,
+    "wof:lastmodified":1582358634,
     "wof:name":"Rio Chico",
     "wof:parent_id":85667991,
     "wof:placetype":"county",

--- a/data/421/198/481/421198481.geojson
+++ b/data/421/198/481/421198481.geojson
@@ -719,6 +719,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459009949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f04b348d2cd4807e095dc88a7802121",
     "wof:hierarchy":[
         {
@@ -729,7 +732,7 @@
         }
     ],
     "wof:id":421198481,
-    "wof:lastmodified":1566588235,
+    "wof:lastmodified":1582358635,
     "wof:name":"Uruguay",
     "wof:parent_id":85668073,
     "wof:placetype":"county",

--- a/data/421/199/805/421199805.geojson
+++ b/data/421/199/805/421199805.geojson
@@ -184,6 +184,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010001,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"04dbd591a9107237ad303df50e20691b",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421199805,
-    "wof:lastmodified":1561793255,
+    "wof:lastmodified":1582358637,
     "wof:name":"Pampa del Infierno",
     "wof:parent_id":421185419,
     "wof:placetype":"locality",

--- a/data/421/199/895/421199895.geojson
+++ b/data/421/199/895/421199895.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae3b99e09802110da819cc6cb47346c6",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421199895,
-    "wof:lastmodified":1566588275,
+    "wof:lastmodified":1582358637,
     "wof:name":"El Cuy",
     "wof:parent_id":85668025,
     "wof:placetype":"county",

--- a/data/421/199/897/421199897.geojson
+++ b/data/421/199/897/421199897.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0abe9711be67b27572c38b8641e2e3f3",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421199897,
-    "wof:lastmodified":1566588279,
+    "wof:lastmodified":1582358637,
     "wof:name":"Presidente Roque Saenz Pe\u00f1a",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/199/899/421199899.geojson
+++ b/data/421/199/899/421199899.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a719a17011ff6f7cc107d45496a9eee",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":421199899,
-    "wof:lastmodified":1566588279,
+    "wof:lastmodified":1582358637,
     "wof:name":"Chos Malal",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/199/903/421199903.geojson
+++ b/data/421/199/903/421199903.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab0ab3f245540505726ed2eaba25ed9a",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421199903,
-    "wof:lastmodified":1566588277,
+    "wof:lastmodified":1582358637,
     "wof:name":"\u00d1orquinco",
     "wof:parent_id":85668025,
     "wof:placetype":"county",

--- a/data/421/199/905/421199905.geojson
+++ b/data/421/199/905/421199905.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94f02d4b2c53c644db15e9f9a1dd6a13",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421199905,
-    "wof:lastmodified":1566588278,
+    "wof:lastmodified":1582358637,
     "wof:name":"Martires",
     "wof:parent_id":85668001,
     "wof:placetype":"county",

--- a/data/421/199/907/421199907.geojson
+++ b/data/421/199/907/421199907.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4159a68679163d7e43380cf77a2adff",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":421199907,
-    "wof:lastmodified":1566588274,
+    "wof:lastmodified":1582358637,
     "wof:name":"San Pedro",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/199/995/421199995.geojson
+++ b/data/421/199/995/421199995.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010008,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"8e5fe694020ad228b61f39e176385495",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421199995,
-    "wof:lastmodified":1566588277,
+    "wof:lastmodified":1582358637,
     "wof:name":"Chos Malal",
     "wof:parent_id":421199899,
     "wof:placetype":"locality",

--- a/data/421/200/145/421200145.geojson
+++ b/data/421/200/145/421200145.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010013,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d81a4f12cda9b101a4499d0acd2e10bd",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421200145,
-    "wof:lastmodified":1566588282,
+    "wof:lastmodified":1582358637,
     "wof:name":"Pirane",
     "wof:parent_id":85668067,
     "wof:placetype":"county",

--- a/data/421/200/653/421200653.geojson
+++ b/data/421/200/653/421200653.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010034,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7eb19a4af7cd049d9bf3327f5fb79bdb",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421200653,
-    "wof:lastmodified":1566588284,
+    "wof:lastmodified":1582358638,
     "wof:name":"Corpen Aike",
     "wof:parent_id":85667991,
     "wof:placetype":"county",

--- a/data/421/200/655/421200655.geojson
+++ b/data/421/200/655/421200655.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010034,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"351fefe62a7ffb43aa2bddf2cee8c884",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421200655,
-    "wof:lastmodified":1566588283,
+    "wof:lastmodified":1582358637,
     "wof:name":"G\u00fcer Aike",
     "wof:parent_id":85667991,
     "wof:placetype":"county",

--- a/data/421/200/997/421200997.geojson
+++ b/data/421/200/997/421200997.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010048,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5bedb3d6b25a96113cedc34d206d6e89",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421200997,
-    "wof:lastmodified":1566588280,
+    "wof:lastmodified":1582358637,
     "wof:name":"General Lopez",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/201/001/421201001.geojson
+++ b/data/421/201/001/421201001.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010048,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df62f3bab5960f7309e68becad11606a",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421201001,
-    "wof:lastmodified":1566588286,
+    "wof:lastmodified":1582358638,
     "wof:name":"Tumbaya",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/202/251/421202251.geojson
+++ b/data/421/202/251/421202251.geojson
@@ -259,6 +259,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dc2d1dcfffbfbef32f19dc03d641873",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
         }
     ],
     "wof:id":421202251,
-    "wof:lastmodified":1566588168,
+    "wof:lastmodified":1582358627,
     "wof:name":"Eldorado",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/202/253/421202253.geojson
+++ b/data/421/202/253/421202253.geojson
@@ -189,6 +189,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23fc890e6fe89664c8df34b38f7d6dc1",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":421202253,
-    "wof:lastmodified":1566588170,
+    "wof:lastmodified":1582358628,
     "wof:name":"San Carlos",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/202/255/421202255.geojson
+++ b/data/421/202/255/421202255.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"953a64e7578f53c0eb4717f587d597e5",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421202255,
-    "wof:lastmodified":1566588170,
+    "wof:lastmodified":1582358628,
     "wof:name":"La Vi\u00f1a",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/202/257/421202257.geojson
+++ b/data/421/202/257/421202257.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3be7b35fc0b2fe758b607c7d4fb68aee",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421202257,
-    "wof:lastmodified":1566588168,
+    "wof:lastmodified":1582358627,
     "wof:name":"Tafi Viejo",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/202/261/421202261.geojson
+++ b/data/421/202/261/421202261.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d174a499d5dc18b2e547e097a8e7608",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421202261,
-    "wof:lastmodified":1566588168,
+    "wof:lastmodified":1582358627,
     "wof:name":"Chilecito",
     "wof:parent_id":85668045,
     "wof:placetype":"county",

--- a/data/421/202/309/421202309.geojson
+++ b/data/421/202/309/421202309.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"044d7766d0c3b6f63015384473c8aa23",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421202309,
-    "wof:lastmodified":1566588167,
+    "wof:lastmodified":1582358627,
     "wof:name":"Picunches",
     "wof:parent_id":85668011,
     "wof:placetype":"county",

--- a/data/421/203/243/421203243.geojson
+++ b/data/421/203/243/421203243.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e441df664669aee2050073b556cdfba5",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421203243,
-    "wof:lastmodified":1566588164,
+    "wof:lastmodified":1582358627,
     "wof:name":"Vinchina",
     "wof:parent_id":85668045,
     "wof:placetype":"county",

--- a/data/421/203/245/421203245.geojson
+++ b/data/421/203/245/421203245.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010145,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32419306e311ffc5cb56cf8670dba061",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421203245,
-    "wof:lastmodified":1566588163,
+    "wof:lastmodified":1582358627,
     "wof:name":"General Manuel Belgrano",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/203/247/421203247.geojson
+++ b/data/421/203/247/421203247.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010145,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"115ddcb25c8492b22bd5bee22737474a",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421203247,
-    "wof:lastmodified":1566588165,
+    "wof:lastmodified":1582358627,
     "wof:name":"Candelaria",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/203/251/421203251.geojson
+++ b/data/421/203/251/421203251.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010145,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34c00512d1f86f10603372be06453d00",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421203251,
-    "wof:lastmodified":1566588164,
+    "wof:lastmodified":1582358627,
     "wof:name":"Iriondo",
     "wof:parent_id":85668077,
     "wof:placetype":"county",

--- a/data/421/203/253/421203253.geojson
+++ b/data/421/203/253/421203253.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010145,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"833ef4596fae75769753abce90c34f36",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
         }
     ],
     "wof:id":421203253,
-    "wof:lastmodified":1566588166,
+    "wof:lastmodified":1582358627,
     "wof:name":"Union",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/203/351/421203351.geojson
+++ b/data/421/203/351/421203351.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010148,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5bc268b2696234e5a70d1b5083b37871",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421203351,
-    "wof:lastmodified":1566588165,
+    "wof:lastmodified":1582358627,
     "wof:name":"Totoral",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/203/353/421203353.geojson
+++ b/data/421/203/353/421203353.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010148,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"390bf53264aa9f3bd6189a3722ac2b44",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421203353,
-    "wof:lastmodified":1566588163,
+    "wof:lastmodified":1582358626,
     "wof:name":"General Pedernera",
     "wof:parent_id":85668029,
     "wof:placetype":"county",

--- a/data/421/203/617/421203617.geojson
+++ b/data/421/203/617/421203617.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010158,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"154199d65f89846a6bb831bda6dfbc74",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421203617,
-    "wof:lastmodified":1566588163,
+    "wof:lastmodified":1582358627,
     "wof:name":"Andalgala",
     "wof:parent_id":85668035,
     "wof:placetype":"county",

--- a/data/421/203/709/421203709.geojson
+++ b/data/421/203/709/421203709.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010161,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2f556cf058edd9ad9e023d9f067f071",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421203709,
-    "wof:lastmodified":1566588163,
+    "wof:lastmodified":1582358627,
     "wof:name":"Pocito",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/421/204/045/421204045.geojson
+++ b/data/421/204/045/421204045.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a09ecbe85afe22ae710ad296338a7f1",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421204045,
-    "wof:lastmodified":1566588158,
+    "wof:lastmodified":1582358626,
     "wof:name":"Belen",
     "wof:parent_id":85668035,
     "wof:placetype":"county",

--- a/data/421/204/047/421204047.geojson
+++ b/data/421/204/047/421204047.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aff3394a8bc3341f274c35f67eca5316",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421204047,
-    "wof:lastmodified":1566588155,
+    "wof:lastmodified":1582358626,
     "wof:name":"Lomas De Zamora",
     "wof:parent_id":85668015,
     "wof:placetype":"county",

--- a/data/421/204/055/421204055.geojson
+++ b/data/421/204/055/421204055.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb4a4937de177ced271928bb8f5bc074",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421204055,
-    "wof:lastmodified":1566588156,
+    "wof:lastmodified":1582358626,
     "wof:name":"Antofagasta De La Sierra",
     "wof:parent_id":85668035,
     "wof:placetype":"county",

--- a/data/421/204/057/421204057.geojson
+++ b/data/421/204/057/421204057.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78f062177beb916ee345b1de7221de17",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421204057,
-    "wof:lastmodified":1566588161,
+    "wof:lastmodified":1582358626,
     "wof:name":"Ischilin",
     "wof:parent_id":85668031,
     "wof:placetype":"county",

--- a/data/421/204/061/421204061.geojson
+++ b/data/421/204/061/421204061.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b252df164be93e66371a3f74bc0e2d6a",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421204061,
-    "wof:lastmodified":1566588160,
+    "wof:lastmodified":1582358626,
     "wof:name":"Humahuaca",
     "wof:parent_id":85668041,
     "wof:placetype":"county",

--- a/data/421/204/063/421204063.geojson
+++ b/data/421/204/063/421204063.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de108a16a900ee3b44aa00f4bc9a13f8",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421204063,
-    "wof:lastmodified":1566588156,
+    "wof:lastmodified":1582358626,
     "wof:name":"Yerba Buena",
     "wof:parent_id":85668059,
     "wof:placetype":"county",

--- a/data/421/204/067/421204067.geojson
+++ b/data/421/204/067/421204067.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e39f0a0655a6a0efd03f94033bfb115b",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421204067,
-    "wof:lastmodified":1566588161,
+    "wof:lastmodified":1582358626,
     "wof:name":"Chicoana",
     "wof:parent_id":85668049,
     "wof:placetype":"county",

--- a/data/421/204/075/421204075.geojson
+++ b/data/421/204/075/421204075.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72ce321808c442e22265ee0aaf149785",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421204075,
-    "wof:lastmodified":1566588159,
+    "wof:lastmodified":1582358626,
     "wof:name":"Deseado",
     "wof:parent_id":85667991,
     "wof:placetype":"county",

--- a/data/421/204/337/421204337.geojson
+++ b/data/421/204/337/421204337.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010181,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb126e921866b39548deb41a2e65a161",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421204337,
-    "wof:lastmodified":1566588153,
+    "wof:lastmodified":1582358626,
     "wof:name":"Santo Tome",
     "wof:parent_id":85668071,
     "wof:placetype":"county",

--- a/data/421/204/755/421204755.geojson
+++ b/data/421/204/755/421204755.geojson
@@ -197,6 +197,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010196,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"b610d5374ef7a51f8cb6055c9a191381",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":421204755,
-    "wof:lastmodified":1566588153,
+    "wof:lastmodified":1582358625,
     "wof:name":"Eldorado",
     "wof:parent_id":421202251,
     "wof:placetype":"locality",

--- a/data/421/204/837/421204837.geojson
+++ b/data/421/204/837/421204837.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010199,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40792ceb7cab1c6dc940f75b7daf3ca2",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421204837,
-    "wof:lastmodified":1566588161,
+    "wof:lastmodified":1582358626,
     "wof:name":"25 De Mayo",
     "wof:parent_id":85668079,
     "wof:placetype":"county",

--- a/data/421/205/537/421205537.geojson
+++ b/data/421/205/537/421205537.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"AR",
     "wof:created":1459010227,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96bea343d88aa39c04396b725909389d",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421205537,
-    "wof:lastmodified":1566588171,
+    "wof:lastmodified":1582358628,
     "wof:name":"Rivadavia",
     "wof:parent_id":85667997,
     "wof:placetype":"county",

--- a/data/856/325/05/85632505.geojson
+++ b/data/856/325/05/85632505.geojson
@@ -1120,7 +1120,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1176,6 +1177,11 @@
     },
     "wof:country":"AR",
     "wof:country_alpha3":"ARG",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"d2e227856be2059214e287445d06303b",
     "wof:hierarchy":[
         {
@@ -1190,7 +1196,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587686,
+    "wof:lastmodified":1582358604,
     "wof:name":"Argentina",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/325/05/85632505.geojson
+++ b/data/856/325/05/85632505.geojson
@@ -1120,8 +1120,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1196,7 +1195,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582358604,
+    "wof:lastmodified":1583239926,
     "wof:name":"Argentina",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/679/91/85667991.geojson
+++ b/data/856/679/91/85667991.geojson
@@ -404,6 +404,9 @@
         "wk:page":"Santa Cruz Province, Argentina"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20b7d152cdd3705bbdeb2c9795acf202",
     "wof:hierarchy":[
         {
@@ -419,7 +422,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587696,
+    "wof:lastmodified":1582358610,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/679/95/85667995.geojson
+++ b/data/856/679/95/85667995.geojson
@@ -548,6 +548,9 @@
         "wd:id":"Q44832"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ba1e1a355e96fbeaed17037f834ba46",
     "wof:hierarchy":[
         {
@@ -563,7 +566,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587695,
+    "wof:lastmodified":1582358609,
     "wof:name":"Tierra del Fuego",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/679/97/85667997.geojson
+++ b/data/856/679/97/85667997.geojson
@@ -385,6 +385,9 @@
         "wk:page":"San Juan Province, Argentina"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29b5ce51019fa74eef9eb8353a0143f0",
     "wof:hierarchy":[
         {
@@ -400,7 +403,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587698,
+    "wof:lastmodified":1582358611,
     "wof:name":"San Juan",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/01/85668001.geojson
+++ b/data/856/680/01/85668001.geojson
@@ -413,6 +413,9 @@
         "wk:page":"Chubut Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f3e0c979e471cb5b9ddef4145c029b0",
     "wof:hierarchy":[
         {
@@ -428,7 +431,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587678,
+    "wof:lastmodified":1582358598,
     "wof:name":"Chubut",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/07/85668007.geojson
+++ b/data/856/680/07/85668007.geojson
@@ -410,6 +410,9 @@
         "wk:page":"Mendoza Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54369150edde46c134f6a3d343c7c5bc",
     "wof:hierarchy":[
         {
@@ -425,7 +428,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587676,
+    "wof:lastmodified":1582358597,
     "wof:name":"Mendoza",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/11/85668011.geojson
+++ b/data/856/680/11/85668011.geojson
@@ -410,6 +410,9 @@
         "wk:page":"Neuqu\u00e9n Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e874fa2637d20e24b6a8ee6c8aba0a90",
     "wof:hierarchy":[
         {
@@ -425,7 +428,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587671,
+    "wof:lastmodified":1582358595,
     "wof:name":"Neuqu\u00e9n",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/15/85668015.geojson
+++ b/data/856/680/15/85668015.geojson
@@ -444,6 +444,9 @@
         "wk:page":"Buenos Aires Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d6a5a5f547daafe9708b33426dd6636",
     "wof:hierarchy":[
         {
@@ -459,7 +462,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587682,
+    "wof:lastmodified":1582358600,
     "wof:name":"Buenos Aires",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/19/85668019.geojson
+++ b/data/856/680/19/85668019.geojson
@@ -390,6 +390,9 @@
         "wk:page":"La Pampa Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"059494e822f840be54121e923163fb80",
     "wof:hierarchy":[
         {
@@ -405,7 +408,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587674,
+    "wof:lastmodified":1582358596,
     "wof:name":"La Pampa",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/25/85668025.geojson
+++ b/data/856/680/25/85668025.geojson
@@ -408,6 +408,9 @@
         "wk:page":"R\u00edo Negro Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04bb9a230d65ff7298a4678e84d531c6",
     "wof:hierarchy":[
         {
@@ -423,7 +426,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587684,
+    "wof:lastmodified":1582358602,
     "wof:name":"Rio Negro",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/29/85668029.geojson
+++ b/data/856/680/29/85668029.geojson
@@ -380,6 +380,9 @@
         "wk:page":"San Luis Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3cd0e252564a9a9991c133b99d38471",
     "wof:hierarchy":[
         {
@@ -395,7 +398,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587672,
+    "wof:lastmodified":1582358595,
     "wof:name":"San Luis",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/31/85668031.geojson
+++ b/data/856/680/31/85668031.geojson
@@ -422,6 +422,9 @@
         "wk:page":"C\u00f3rdoba Province, Argentina"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f587675c2cfd39fca6318666998b022",
     "wof:hierarchy":[
         {
@@ -437,7 +440,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587677,
+    "wof:lastmodified":1582358598,
     "wof:name":"C\u00f3rdoba",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/35/85668035.geojson
+++ b/data/856/680/35/85668035.geojson
@@ -404,6 +404,9 @@
         "wk:page":"Catamarca Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f178fd30d001538e8e5f9441ebf32455",
     "wof:hierarchy":[
         {
@@ -419,7 +422,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587670,
+    "wof:lastmodified":1582358594,
     "wof:name":"Catamarca",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/41/85668041.geojson
+++ b/data/856/680/41/85668041.geojson
@@ -401,6 +401,9 @@
         "wk:page":"Jujuy Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07c381a1175235abef9c17f3c7fcf98b",
     "wof:hierarchy":[
         {
@@ -416,7 +419,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587681,
+    "wof:lastmodified":1582358600,
     "wof:name":"Jujuy",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/45/85668045.geojson
+++ b/data/856/680/45/85668045.geojson
@@ -407,6 +407,9 @@
         "wk:page":"La Rioja Province, Argentina"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9cb6ac295b1a7150faa7483c2ea3d66a",
     "wof:hierarchy":[
         {
@@ -422,7 +425,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587673,
+    "wof:lastmodified":1582358596,
     "wof:name":"La Rioja",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/49/85668049.geojson
+++ b/data/856/680/49/85668049.geojson
@@ -392,6 +392,9 @@
         "wk:page":"Salta Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a57c5cf47bde765ba7e56efde526c72",
     "wof:hierarchy":[
         {
@@ -407,7 +410,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587683,
+    "wof:lastmodified":1582358601,
     "wof:name":"Salta",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/53/85668053.geojson
+++ b/data/856/680/53/85668053.geojson
@@ -381,6 +381,9 @@
         "wk:page":"Santiago del Estero Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"725ee4045ed1a4c00f6b0b21dac191b3",
     "wof:hierarchy":[
         {
@@ -396,7 +399,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587678,
+    "wof:lastmodified":1582358598,
     "wof:name":"Santiago del Estero",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/59/85668059.geojson
+++ b/data/856/680/59/85668059.geojson
@@ -406,6 +406,9 @@
         "wk:page":"Tucum\u00e1n Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfc0b12219cbe6f23a5f036c89016bf4",
     "wof:hierarchy":[
         {
@@ -421,7 +424,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587669,
+    "wof:lastmodified":1582358594,
     "wof:name":"Tucum\u00e1n",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/63/85668063.geojson
+++ b/data/856/680/63/85668063.geojson
@@ -412,6 +412,9 @@
         "wk:page":"Chaco Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e820c0a4bb0dfa09a365ae2fe5ac3405",
     "wof:hierarchy":[
         {
@@ -427,7 +430,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587680,
+    "wof:lastmodified":1582358600,
     "wof:name":"Chaco",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/67/85668067.geojson
+++ b/data/856/680/67/85668067.geojson
@@ -386,6 +386,9 @@
         "wk:page":"Formosa Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91dded4dab7f7f0f86c824732ce062c0",
     "wof:hierarchy":[
         {
@@ -401,7 +404,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587671,
+    "wof:lastmodified":1582358594,
     "wof:name":"Formosa",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/71/85668071.geojson
+++ b/data/856/680/71/85668071.geojson
@@ -401,6 +401,9 @@
         "wk:page":"Corrientes Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d9830a38b64bfc876b386674844db16",
     "wof:hierarchy":[
         {
@@ -416,7 +419,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587682,
+    "wof:lastmodified":1582358601,
     "wof:name":"Corrientes",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/73/85668073.geojson
+++ b/data/856/680/73/85668073.geojson
@@ -412,6 +412,9 @@
         "wk:page":"Entre R\u00edos Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c813cbf13a9311e58fae3f1dcfcd19c",
     "wof:hierarchy":[
         {
@@ -427,7 +430,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587673,
+    "wof:lastmodified":1582358596,
     "wof:name":"Entre Rios",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/77/85668077.geojson
+++ b/data/856/680/77/85668077.geojson
@@ -398,6 +398,9 @@
         "wk:page":"Santa Fe Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b5794895d184e6f495ba7781bf0ca50",
     "wof:hierarchy":[
         {
@@ -413,7 +416,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587681,
+    "wof:lastmodified":1582358600,
     "wof:name":"Santa Fe",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/79/85668079.geojson
+++ b/data/856/680/79/85668079.geojson
@@ -399,6 +399,9 @@
         "wk:page":"Misiones Province"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"776b5fcf431e09fedea53f19ca8f4740",
     "wof:hierarchy":[
         {
@@ -414,7 +417,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587680,
+    "wof:lastmodified":1582358600,
     "wof:name":"Misiones",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/856/680/81/85668081.geojson
+++ b/data/856/680/81/85668081.geojson
@@ -834,6 +834,10 @@
         421174285
     ],
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa4b9f8e19f98ba1654e26398ce3cdc9",
     "wof:hierarchy":[
         {
@@ -849,7 +853,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566587675,
+    "wof:lastmodified":1582358596,
     "wof:name":"Ciudad de Buenos Aires",
     "wof:parent_id":85632505,
     "wof:placetype":"region",

--- a/data/857/640/25/85764025.geojson
+++ b/data/857/640/25/85764025.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Agronom\u00eda"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4cbf763f0849006bfb165be7afb006e",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587666,
+    "wof:lastmodified":1582358592,
     "wof:name":"Agronom\u00eda",
     "wof:parent_id":1109371881,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/29/85764029.geojson
+++ b/data/857/640/29/85764029.geojson
@@ -116,6 +116,9 @@
         "qs_pg:id":1053746
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e7f8dc7ee5a7a35455e5de6cabc8471",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587664,
+    "wof:lastmodified":1582358591,
     "wof:name":"Alberdi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/35/85764035.geojson
+++ b/data/857/640/35/85764035.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Almagro, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94a35f3d5b60dc89b41084bcce344881",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587664,
+    "wof:lastmodified":1582358591,
     "wof:name":"Almagro",
     "wof:parent_id":1109371859,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/39/85764039.geojson
+++ b/data/857/640/39/85764039.geojson
@@ -103,6 +103,9 @@
         "qs_pg:id":900029
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a745589fefdb4d9280e23150d2c212ac",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587665,
+    "wof:lastmodified":1582358591,
     "wof:name":"Alta C\u00f3rdoba",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/43/85764043.geojson
+++ b/data/857/640/43/85764043.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":1074933
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba15d2343397f10fc9c25e992f0f28a0",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587664,
+    "wof:lastmodified":1582358591,
     "wof:name":"Ant\u00e1rtida Argentina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/45/85764045.geojson
+++ b/data/857/640/45/85764045.geojson
@@ -83,6 +83,9 @@
         "qs:id":1080375
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69ce4f1871765add2d4a26be7565a28a",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379086,
+    "wof:lastmodified":1582358591,
     "wof:name":"Arroyito",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/55/85764055.geojson
+++ b/data/857/640/55/85764055.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Barracas, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f32c3b9eb9bf9e76f0a7c9bb83e4e221",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587665,
+    "wof:lastmodified":1582358592,
     "wof:name":"Barracas",
     "wof:parent_id":1109371857,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/61/85764061.geojson
+++ b/data/857/640/61/85764061.geojson
@@ -179,6 +179,9 @@
         "wk:page":"Belgrano, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f89a0869f003874363640bd27faad56",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587664,
+    "wof:lastmodified":1582358591,
     "wof:name":"Belgrano",
     "wof:parent_id":1109371877,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/65/85764065.geojson
+++ b/data/857/640/65/85764065.geojson
@@ -75,6 +75,9 @@
         "qs:id":1114200
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84b3cba9825cf86398bfdc9c816b3014",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379086,
+    "wof:lastmodified":1582358591,
     "wof:name":"Bella Vista",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/71/85764071.geojson
+++ b/data/857/640/71/85764071.geojson
@@ -177,6 +177,9 @@
         "wk:page":"La Boca"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3a35c0e4af43cd2a2cbe6e4d9429c66",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587666,
+    "wof:lastmodified":1582358592,
     "wof:name":"La Boca",
     "wof:parent_id":1109371857,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/73/85764073.geojson
+++ b/data/857/640/73/85764073.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Boedo"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65588e7e9aad72a7f04396307d7dbd47",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587664,
+    "wof:lastmodified":1582358591,
     "wof:name":"Boedo",
     "wof:parent_id":1109371859,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/79/85764079.geojson
+++ b/data/857/640/79/85764079.geojson
@@ -149,6 +149,9 @@
         "wk:page":"Caballito, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b094ef752540b8b4c1c18c209edf87c",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587665,
+    "wof:lastmodified":1582358592,
     "wof:name":"Caballito",
     "wof:parent_id":1109371861,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/93/85764093.geojson
+++ b/data/857/640/93/85764093.geojson
@@ -75,6 +75,9 @@
         "qs:id":1120366
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"26ad4e97dcc1f601bacf8222ce77da0b",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379085,
+    "wof:lastmodified":1582358591,
     "wof:name":"Calzada",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/99/85764099.geojson
+++ b/data/857/640/99/85764099.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Chacarita, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58c17605c34acb7900385358d3371c0e",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587665,
+    "wof:lastmodified":1582358591,
     "wof:name":"Chacarrita",
     "wof:parent_id":1109371881,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/03/85764103.geojson
+++ b/data/857/641/03/85764103.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Coghlan, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e55a2e0554462a4bef78691874876fb",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587666,
+    "wof:lastmodified":1582358592,
     "wof:name":"Coghlan",
     "wof:parent_id":1109371875,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/09/85764109.geojson
+++ b/data/857/641/09/85764109.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Colegiales"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82a6823104408aa46410a13b3e798477",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587668,
+    "wof:lastmodified":1582358592,
     "wof:name":"Colegiales",
     "wof:parent_id":1109371877,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/17/85764117.geojson
+++ b/data/857/641/17/85764117.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Constituci\u00f3n, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4aaa0fc317f26d16d47742137b41513",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587667,
+    "wof:lastmodified":1582358592,
     "wof:name":"Constituci\u00f3n",
     "wof:parent_id":1109371849,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/19/85764119.geojson
+++ b/data/857/641/19/85764119.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Flores, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b7e13e2a5ecb31fb5c23856b2fbee49",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587667,
+    "wof:lastmodified":1582358592,
     "wof:name":"Flores",
     "wof:parent_id":1109371863,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/25/85764125.geojson
+++ b/data/857/641/25/85764125.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Floresta, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"599692bf6506cdba744d4515fcd2302b",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587668,
+    "wof:lastmodified":1582358592,
     "wof:name":"Floresta",
     "wof:parent_id":1109371871,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/33/85764133.geojson
+++ b/data/857/641/33/85764133.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Villa Urquiza"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"365fa0421b0eb06723faf92af3f44b9e",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587667,
+    "wof:lastmodified":1582358592,
     "wof:name":"Villa Urquiza",
     "wof:parent_id":1109371875,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/39/85764139.geojson
+++ b/data/857/641/39/85764139.geojson
@@ -96,6 +96,9 @@
         "qs:id":351989
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d8cba24f608c19b9e05ee083d1a750c",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379086,
+    "wof:lastmodified":1582358592,
     "wof:name":"La Florida",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/49/85764149.geojson
+++ b/data/857/641/49/85764149.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Liniers"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05e1aba254fdfccd846a8a64dfa86f0d",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587668,
+    "wof:lastmodified":1582358592,
     "wof:name":"Liniers",
     "wof:parent_id":1109371867,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/75/85764175.geojson
+++ b/data/857/641/75/85764175.geojson
@@ -119,6 +119,9 @@
         "qs_pg:id":1062666
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"beab638382975aa0a076f02922ae65ec",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587668,
+    "wof:lastmodified":1582358592,
     "wof:name":"Liniers",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/641/93/85764193.geojson
+++ b/data/857/641/93/85764193.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Mataderos"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b4a268a97a839c8edad86dbd457038d",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587667,
+    "wof:lastmodified":1582358592,
     "wof:name":"Mataderos",
     "wof:parent_id":1109371867,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/01/85764201.geojson
+++ b/data/857/642/01/85764201.geojson
@@ -104,6 +104,9 @@
         "qs_pg:id":1341646
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c8622d446833d7847b9c5e32dc001bd",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587661,
+    "wof:lastmodified":1582358590,
     "wof:name":"Matheu",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/05/85764205.geojson
+++ b/data/857/642/05/85764205.geojson
@@ -133,6 +133,9 @@
         "wk:page":"Monte Castro"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3471e42f76d953c04a0da8f912ad380",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587658,
+    "wof:lastmodified":1582358590,
     "wof:name":"Monte Castro",
     "wof:parent_id":1109371871,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/09/85764209.geojson
+++ b/data/857/642/09/85764209.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Monserrat, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d04fe0503587f1d2694487978b0e75c9",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587661,
+    "wof:lastmodified":1582358590,
     "wof:name":"Montserrat",
     "wof:parent_id":1109371849,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/11/85764211.geojson
+++ b/data/857/642/11/85764211.geojson
@@ -136,6 +136,9 @@
         "qs_pg:id":319710
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10c8a685987aac2201ea87ca22da0907",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587659,
+    "wof:lastmodified":1582358590,
     "wof:name":"Moreno",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/21/85764221.geojson
+++ b/data/857/642/21/85764221.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":1075008
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97223ccc1e68eb131ae6bf8ef6c22fa6",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587660,
+    "wof:lastmodified":1582358590,
     "wof:name":"Nueva Fisherton",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/25/85764225.geojson
+++ b/data/857/642/25/85764225.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Nueva Pompeya"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b15c9957bab53b0005283eb193cc0b4",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587662,
+    "wof:lastmodified":1582358591,
     "wof:name":"Nueva Pompeya",
     "wof:parent_id":1109371857,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/27/85764227.geojson
+++ b/data/857/642/27/85764227.geojson
@@ -147,6 +147,9 @@
         "wk:page":"N\u00fa\u00f1ez, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"217b2b034b59107fcf12fb2cb060376f",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587659,
+    "wof:lastmodified":1582358590,
     "wof:name":"N\u00fa\u00f1ez",
     "wof:parent_id":1109371877,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/35/85764235.geojson
+++ b/data/857/642/35/85764235.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Palermo, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"931a572e2a7281c87b245271c40ac010",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587658,
+    "wof:lastmodified":1582358589,
     "wof:name":"Palermo",
     "wof:parent_id":1109371879,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/39/85764239.geojson
+++ b/data/857/642/39/85764239.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Parque Chacabuco"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfc8a38a8891f29d81e593d8c62a64c9",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587661,
+    "wof:lastmodified":1582358590,
     "wof:name":"Parque Chacabuco",
     "wof:parent_id":1109371863,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/43/85764243.geojson
+++ b/data/857/642/43/85764243.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Parque Chas"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ea9057e8528563d31a9ffb738f39adc",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587660,
+    "wof:lastmodified":1582358590,
     "wof:name":"Parque Chas",
     "wof:parent_id":1109371881,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/47/85764247.geojson
+++ b/data/857/642/47/85764247.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Parque Patricios"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dda8da63ff64ab430d592f39cad6e1f5",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587662,
+    "wof:lastmodified":1582358591,
     "wof:name":"Parque Patricios",
     "wof:parent_id":1109371857,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/51/85764251.geojson
+++ b/data/857/642/51/85764251.geojson
@@ -127,6 +127,9 @@
         "wk:page":"La Paternal, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9aaac1287a31bd004539ef3bf2390403",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587658,
+    "wof:lastmodified":1582358590,
     "wof:name":"La Paternal",
     "wof:parent_id":1109371881,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/63/85764263.geojson
+++ b/data/857/642/63/85764263.geojson
@@ -149,6 +149,10 @@
         "wk:page":"Puerto Madero"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"54b9e84fa70e14166b605853e77b67e9",
     "wof:hierarchy":[
         {
@@ -164,7 +168,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587661,
+    "wof:lastmodified":1582358591,
     "wof:name":"Puerto Madero",
     "wof:parent_id":1109371849,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/71/85764271.geojson
+++ b/data/857/642/71/85764271.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Villa Pueyrred\u00f3n"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05c3f8912e7976a7f3c19bfc0c1d9167",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587662,
+    "wof:lastmodified":1582358591,
     "wof:name":"Villa Pueyrred\u00f3n",
     "wof:parent_id":1109371875,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/73/85764273.geojson
+++ b/data/857/642/73/85764273.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Recoleta, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7085b47dfa8269c23fcff68767cce8f6",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587659,
+    "wof:lastmodified":1582358590,
     "wof:name":"Recoleta",
     "wof:parent_id":1109371853,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/75/85764275.geojson
+++ b/data/857/642/75/85764275.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Retiro, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"410a06e228c9d4197d152c1b82d41044",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587660,
+    "wof:lastmodified":1582358590,
     "wof:name":"Retiro",
     "wof:parent_id":1109371849,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/79/85764279.geojson
+++ b/data/857/642/79/85764279.geojson
@@ -133,6 +133,9 @@
         "qs_pg:id":1114201
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"093a24205ad5735599001b6e5995606c",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587662,
+    "wof:lastmodified":1582358591,
     "wof:name":"Rivadavia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/81/85764281.geojson
+++ b/data/857/642/81/85764281.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Saavedra, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"370461dcc1a7a1ead827ae3ca021fdf2",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587660,
+    "wof:lastmodified":1582358590,
     "wof:name":"Saavedra",
     "wof:parent_id":1109371875,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/83/85764283.geojson
+++ b/data/857/642/83/85764283.geojson
@@ -75,6 +75,9 @@
         "qs:id":281704
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29b9e58211c5ca45db53557555658d70",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379086,
+    "wof:lastmodified":1582358591,
     "wof:name":"Saladillo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/87/85764287.geojson
+++ b/data/857/642/87/85764287.geojson
@@ -138,6 +138,9 @@
         "wk:page":"San Crist\u00f3bal, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d66378be182c9d0fa3f73bf859fa9b88",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587659,
+    "wof:lastmodified":1582358590,
     "wof:name":"San Crist\u00f3bal",
     "wof:parent_id":1109371855,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/89/85764289.geojson
+++ b/data/857/642/89/85764289.geojson
@@ -162,6 +162,9 @@
         "wk:page":"San Telmo, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15f356ea2cca9d56769f678c3a2cc682",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587659,
+    "wof:lastmodified":1582358590,
     "wof:name":"San Telmo",
     "wof:parent_id":1109371849,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/91/85764291.geojson
+++ b/data/857/642/91/85764291.geojson
@@ -257,6 +257,9 @@
         "qs_pg:id":389088
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf1d92afa07e65bf36c85b05c22c92a6",
     "wof:hierarchy":[
         {
@@ -272,7 +275,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587661,
+    "wof:lastmodified":1582358590,
     "wof:name":"Sorrento",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/642/97/85764297.geojson
+++ b/data/857/642/97/85764297.geojson
@@ -126,6 +126,9 @@
         "qs_pg:id":1075048
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4aa03a3c7b780d8cf4639afb678a8585",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587661,
+    "wof:lastmodified":1582358590,
     "wof:name":"Uni\u00f3n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/01/85764301.geojson
+++ b/data/857/643/01/85764301.geojson
@@ -141,6 +141,9 @@
         "wk:page":"V\u00e9lez S\u00e1rsfield (barrio)"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84826edf385e718042545b9fc941fddb",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587657,
+    "wof:lastmodified":1582358589,
     "wof:name":"V\u00e9lez Sarsfield",
     "wof:parent_id":1109371871,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/07/85764307.geojson
+++ b/data/857/643/07/85764307.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Villa Crespo"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"077066407ea0153f5dad2567f02cbf90",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587657,
+    "wof:lastmodified":1582358589,
     "wof:name":"Villa Crespo",
     "wof:parent_id":1109371881,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/11/85764311.geojson
+++ b/data/857/643/11/85764311.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Villa Devoto"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0433e6cd9dc49187199a5fe03891f5c",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587656,
+    "wof:lastmodified":1582358588,
     "wof:name":"Villa Devoto",
     "wof:parent_id":1109371873,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/15/85764315.geojson
+++ b/data/857/643/15/85764315.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Villa General Mitre"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"09f8f07c7ca0c797a5f0e50c36aaffb4",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587657,
+    "wof:lastmodified":1582358589,
     "wof:name":"Villa General Mitre",
     "wof:parent_id":1109371873,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/19/85764319.geojson
+++ b/data/857/643/19/85764319.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Villa Lugano"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e40f507d6ba7decb99fc6f7f3130755",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587656,
+    "wof:lastmodified":1582358588,
     "wof:name":"Villa Lugano",
     "wof:parent_id":1109371865,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/25/85764325.geojson
+++ b/data/857/643/25/85764325.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Villa Luro"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"086797d4c8bf9a14cd53b0955cf4e6f1",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587657,
+    "wof:lastmodified":1582358589,
     "wof:name":"Villa Luro",
     "wof:parent_id":1109371871,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/29/85764329.geojson
+++ b/data/857/643/29/85764329.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Villa Ort\u00fazar"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07f39769641302c9ef29450fea31cdfb",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587656,
+    "wof:lastmodified":1582358588,
     "wof:name":"Villa Ort\u00fazar",
     "wof:parent_id":1109371881,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/33/85764333.geojson
+++ b/data/857/643/33/85764333.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Villa Real, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a888b8639c470d0cc3fa064d213b6416",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587656,
+    "wof:lastmodified":1582358587,
     "wof:name":"Villa Real",
     "wof:parent_id":1109371871,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/43/85764343.geojson
+++ b/data/857/643/43/85764343.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1120436
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30856e24737cec83af218ed3ff55c51d",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587656,
+    "wof:lastmodified":1582358589,
     "wof:name":"Villa Revol",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/47/85764347.geojson
+++ b/data/857/643/47/85764347.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Villa Riachuelo"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77d5338381ec7f0fd12032914cbb5826",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587657,
+    "wof:lastmodified":1582358589,
     "wof:name":"Villa Riachuelo",
     "wof:parent_id":1109371865,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/49/85764349.geojson
+++ b/data/857/643/49/85764349.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Villa Soldati"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fbde9cf3d888ee4d332e8b7103cfd50",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587657,
+    "wof:lastmodified":1582358589,
     "wof:name":"Villa Soldati",
     "wof:parent_id":1109371865,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/07/85765607.geojson
+++ b/data/857/656/07/85765607.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Villa Santa Rita"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c52d165230cca7b8b2e6cb61f1b264a0",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587663,
+    "wof:lastmodified":1582358591,
     "wof:name":"Villa Santa Rita",
     "wof:parent_id":1109371873,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/11/85765611.geojson
+++ b/data/857/656/11/85765611.geojson
@@ -129,6 +129,9 @@
         "wk:page":"San Nicol\u00e1s, Buenos Aires"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"204cb7a9c53f8738d75fed2d930df6c1",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587663,
+    "wof:lastmodified":1582358591,
     "wof:name":"San Nicolas",
     "wof:parent_id":1109371849,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/13/85765613.geojson
+++ b/data/857/656/13/85765613.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Balvanera"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea9952ac59c4b2d37ed9e10e758c8558",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587663,
+    "wof:lastmodified":1582358591,
     "wof:name":"Balvanera",
     "wof:parent_id":1109371855,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/19/85765619.geojson
+++ b/data/857/656/19/85765619.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Parque Avellaneda"
     },
     "wof:country":"AR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"929c8e005490d02f5666c07c3ca378fa",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566587663,
+    "wof:lastmodified":1582358591,
     "wof:name":"Parque Avellaneda",
     "wof:parent_id":1109371867,
     "wof:placetype":"neighbourhood",

--- a/data/890/429/471/890429471.geojson
+++ b/data/890/429/471/890429471.geojson
@@ -196,6 +196,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469051815,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"da9e37c3f35df8072ec7309f1d232d48",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":890429471,
-    "wof:lastmodified":1566588361,
+    "wof:lastmodified":1582358645,
     "wof:name":"Perito Moreno",
     "wof:parent_id":421170133,
     "wof:placetype":"locality",

--- a/data/890/433/769/890433769.geojson
+++ b/data/890/433/769/890433769.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469051994,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"f3fad42db1de649788e49012a49bc405",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":890433769,
-    "wof:lastmodified":1566588366,
+    "wof:lastmodified":1582358646,
     "wof:name":"General Conesa",
     "wof:parent_id":1108718389,
     "wof:placetype":"locality",

--- a/data/890/435/489/890435489.geojson
+++ b/data/890/435/489/890435489.geojson
@@ -389,6 +389,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469052070,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3eeda470bf05bf27b62633ee5461a497",
     "wof:hierarchy":[
         {
@@ -400,7 +403,7 @@
         }
     ],
     "wof:id":890435489,
-    "wof:lastmodified":1566588368,
+    "wof:lastmodified":1582358646,
     "wof:name":"Ushuaia",
     "wof:parent_id":1108718533,
     "wof:placetype":"locality",

--- a/data/890/435/505/890435505.geojson
+++ b/data/890/435/505/890435505.geojson
@@ -178,6 +178,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469052070,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"d735da6f93bac220b73d3425ac1358cd",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":890435505,
-    "wof:lastmodified":1566588367,
+    "wof:lastmodified":1582358646,
     "wof:name":"Victorica",
     "wof:parent_id":1108718309,
     "wof:placetype":"locality",

--- a/data/890/437/223/890437223.geojson
+++ b/data/890/437/223/890437223.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469052143,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"d182c84c6e84e5c66731602ddaf25569",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
         }
     ],
     "wof:id":890437223,
-    "wof:lastmodified":1566588357,
+    "wof:lastmodified":1582358645,
     "wof:name":"Puerto Deseado",
     "wof:parent_id":421204075,
     "wof:placetype":"locality",

--- a/data/890/437/285/890437285.geojson
+++ b/data/890/437/285/890437285.geojson
@@ -358,6 +358,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469052145,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fe97f31a3fb495f936709b4fc043e81",
     "wof:hierarchy":[
         {
@@ -369,7 +372,7 @@
         }
     ],
     "wof:id":890437285,
-    "wof:lastmodified":1566588357,
+    "wof:lastmodified":1582358645,
     "wof:name":"Santiago del Estero",
     "wof:parent_id":1108718475,
     "wof:placetype":"locality",

--- a/data/890/437/593/890437593.geojson
+++ b/data/890/437/593/890437593.geojson
@@ -225,6 +225,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469052157,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"906feff286bb4714aa891b6498763f59",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":890437593,
-    "wof:lastmodified":1566588356,
+    "wof:lastmodified":1582358645,
     "wof:name":"San Carlos de Bariloche",
     "wof:parent_id":421188061,
     "wof:placetype":"locality",

--- a/data/890/440/225/890440225.geojson
+++ b/data/890/440/225/890440225.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469052267,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"b5d9e8ce04def58be3a44aa508b4621d",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":890440225,
-    "wof:lastmodified":1561793264,
+    "wof:lastmodified":1582358645,
     "wof:name":"Charata",
     "wof:parent_id":1108718193,
     "wof:placetype":"locality",

--- a/data/890/445/477/890445477.geojson
+++ b/data/890/445/477/890445477.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"AR",
     "wof:created":1469052511,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"647ec06abdbd72f50b7e4f209347e7c3",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":890445477,
-    "wof:lastmodified":1561793268,
+    "wof:lastmodified":1582358645,
     "wof:name":"Las Lomitas",
     "wof:parent_id":1108718267,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.